### PR TITLE
chore: drop redundant keymap in demo

### DIFF
--- a/apps/demo/src/main.ts
+++ b/apps/demo/src/main.ts
@@ -39,7 +39,6 @@ const editor = new EditorView({
     pasteRichTextExtension(),
     pastePlainTextExtension(),
     keymap.of([
-      indentWithTab,
       {
         key: 'Alt-p',
         run: (view) => {


### PR DESCRIPTION
`indentWithTab` is already included in `prosemarkBasicSetup()`.