### PR TITLE
Spellcheck dropdown navigation

### DIFF
--- a/.changeset/spellcheck-tooltip-keyboard-nav.md
+++ b/.changeset/spellcheck-tooltip-keyboard-nav.md
@@ -1,0 +1,5 @@
+---
+'@prosemark/spellcheck-frontend': patch
+---
+
+Fix spellcheck tooltip keyboard interactions by improving ArrowUp/ArrowDown navigation reliability, ensuring Enter activates the focused item, and restoring editor focus after selection.

--- a/apps/demo/src/main.ts
+++ b/apps/demo/src/main.ts
@@ -54,7 +54,7 @@ const editor = new EditorView({
     indentUnit.of('\t'),
     // traverseTreePlugin,
   ],
-  doc: "- Howdy",// initDoc,
+  doc: initDoc,
   parent: document.getElementById('codemirror-container')!,
 });
 

--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -66,6 +66,10 @@ export default defineConfig({
   resolve: {
     alias: {
       buffer: 'buffer',
+      '@prosemark/spellcheck-frontend': resolve(
+        process.cwd(),
+        '../../packages/spellcheck-frontend/lib/main.ts',
+      ),
     },
   },
   optimizeDeps: {

--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -1,9 +1,38 @@
 import { defineConfig } from 'vite';
-import { readFileSync } from 'fs';
+import { appendFileSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [
+    {
+      name: 'spellcheck-debug-log-endpoint',
+      configureServer(server) {
+        server.middlewares.use('/__spellcheck_debug_log', (req, res, next) => {
+          if (req.method !== 'POST') {
+            next();
+            return;
+          }
+          let body = '';
+          req.on('data', (chunk) => {
+            body += chunk.toString();
+          });
+          req.on('end', () => {
+            try {
+              const parsed = JSON.parse(body) as unknown;
+              appendFileSync(
+                '/opt/cursor/logs/debug.log',
+                `${JSON.stringify(parsed)}\n`,
+              );
+              res.statusCode = 204;
+              res.end();
+            } catch {
+              res.statusCode = 400;
+              res.end('invalid debug payload');
+            }
+          });
+        });
+      },
+    },
     {
       name: 'dictionary-loader',
       load(id) {

--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -37,10 +37,6 @@ export default defineConfig({
   resolve: {
     alias: {
       buffer: 'buffer',
-      '@prosemark/spellcheck-frontend': resolve(
-        process.cwd(),
-        '../../packages/spellcheck-frontend/lib/main.ts',
-      ),
     },
   },
   optimizeDeps: {

--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -1,38 +1,9 @@
 import { defineConfig } from 'vite';
-import { appendFileSync, readFileSync } from 'fs';
+import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [
-    {
-      name: 'spellcheck-debug-log-endpoint',
-      configureServer(server) {
-        server.middlewares.use('/__spellcheck_debug_log', (req, res, next) => {
-          if (req.method !== 'POST') {
-            next();
-            return;
-          }
-          let body = '';
-          req.on('data', (chunk) => {
-            body += chunk.toString();
-          });
-          req.on('end', () => {
-            try {
-              const parsed = JSON.parse(body) as unknown;
-              appendFileSync(
-                '/opt/cursor/logs/debug.log',
-                `${JSON.stringify(parsed)}\n`,
-              );
-              res.statusCode = 204;
-              res.end();
-            } catch {
-              res.statusCode = 400;
-              res.end('invalid debug payload');
-            }
-          });
-        });
-      },
-    },
     {
       name: 'dictionary-loader',
       load(id) {

--- a/packages/spellcheck-frontend/lib/main.ts
+++ b/packages/spellcheck-frontend/lib/main.ts
@@ -117,6 +117,7 @@ export {
   contextMenuHandler,
   spellcheckKeymap,
   closeTooltipHandlers,
+  tooltipHandlers,
   type SpellcheckAction,
   type SpellcheckActionsConfig,
   suggestionFetcher,

--- a/packages/spellcheck-frontend/lib/tooltip.ts
+++ b/packages/spellcheck-frontend/lib/tooltip.ts
@@ -1,4 +1,4 @@
-import { Facet, StateEffect, StateField } from '@codemirror/state';
+import { Facet, Prec, StateEffect, StateField } from '@codemirror/state';
 import {
   EditorView,
   showTooltip,
@@ -45,11 +45,19 @@ export const setTooltip = StateEffect.define<Tooltip | null>();
 const spellcheckTooltipItemSelector = '.cm-spellcheck-tooltip-item';
 
 function getTooltipElement(view: EditorView): HTMLElement | null {
-  return view.dom.closest('.cm-editor')?.querySelector('.cm-spellcheck-tooltip');
+  const localTooltip = view.dom
+    .closest('.cm-editor')
+    ?.querySelector<HTMLElement>('.cm-spellcheck-tooltip');
+  if (localTooltip) {
+    return localTooltip;
+  }
+  return view.dom.ownerDocument.querySelector<HTMLElement>(
+    '.cm-spellcheck-tooltip',
+  );
 }
 
 function moveTooltipFocus(
-  container: ParentNode,
+  container: HTMLElement,
   direction: 'up' | 'down',
 ): boolean {
   const items = Array.from(
@@ -407,7 +415,8 @@ export const closeTooltipHandlers = [
       return false;
     },
   }),
-  keymap.of([
+  Prec.highest(
+    keymap.of([
     {
       key: 'ArrowDown',
       run: (view) => {
@@ -439,7 +448,8 @@ export const closeTooltipHandlers = [
         return false;
       },
     },
-  ]),
+    ]),
+  ),
 ];
 
 export const spellcheckTooltipTheme = EditorView.theme({
@@ -514,6 +524,12 @@ export const spellcheckTooltipTheme = EditorView.theme({
   },
   '.cm-spellcheck-tooltip-item:hover': {
     backgroundColor: 'var(--pm-spellcheck-tooltip-hover, #f0f0f0)',
+  },
+  '.cm-spellcheck-tooltip-item:focus-visible': {
+    backgroundColor: 'var(--pm-spellcheck-tooltip-hover, #f0f0f0)',
+    outline:
+      '1px solid var(--pm-spellcheck-tooltip-focus, var(--pm-spellcheck-issue-underline-color, #037bfc))',
+    outlineOffset: '0',
   },
   '.cm-spellcheck-tooltip-item-preferred': {
     fontWeight: '600',

--- a/packages/spellcheck-frontend/lib/tooltip.ts
+++ b/packages/spellcheck-frontend/lib/tooltip.ts
@@ -61,7 +61,9 @@ function moveTooltipFocus(
   direction: 'up' | 'down',
 ): boolean {
   const items = Array.from(
-    container.querySelectorAll<HTMLButtonElement>(spellcheckTooltipItemSelector),
+    container.querySelectorAll<HTMLButtonElement>(
+      spellcheckTooltipItemSelector,
+    ),
   );
   if (items.length === 0) {
     return false;
@@ -431,7 +433,7 @@ export const spellcheckKeymap = keymap.of([
 ]);
 
 // Close tooltip on click outside or escape key
-export const closeTooltipHandlers = [
+export const tooltipHandlers = [
   EditorView.domEventHandlers({
     mousedown(event, view) {
       // Don't close if clicking inside the tooltip
@@ -497,6 +499,9 @@ export const closeTooltipHandlers = [
     ]),
   ),
 ];
+
+// @deprecated use tooltipHandlers instead
+export const closeTooltipHandlers = tooltipHandlers;
 
 export const spellcheckTooltipTheme = EditorView.theme({
   '.cm-spellcheck-tooltip': {
@@ -586,6 +591,6 @@ export const spellcheckTooltipExtension = [
   tooltipState,
   contextMenuHandler,
   spellcheckKeymap,
-  ...closeTooltipHandlers,
+  ...tooltipHandlers,
   spellcheckTooltipTheme,
 ];

--- a/packages/spellcheck-frontend/lib/tooltip.ts
+++ b/packages/spellcheck-frontend/lib/tooltip.ts
@@ -95,6 +95,12 @@ function moveTooltipFocusFromEditor(
   return moveTooltipFocus(tooltipElement, direction);
 }
 
+function focusEditor(view: EditorView): void {
+  queueMicrotask(() => {
+    view.focus();
+  });
+}
+
 // Class that implements TooltipView to manage spellcheck tooltip content
 class SpellcheckTooltipView implements TooltipView {
   public readonly dom: HTMLElement;
@@ -243,6 +249,7 @@ class SpellcheckTooltipView implements TooltipView {
           }
         } finally {
           view.dispatch({ effects: setTooltip.of(null) });
+          focusEditor(view);
         }
       };
       actionsList.appendChild(item);
@@ -308,6 +315,7 @@ class SpellcheckTooltipView implements TooltipView {
     });
     // Close tooltip
     view.dispatch({ effects: setTooltip.of(null) });
+    focusEditor(view);
   }
 
   destroy(): void {

--- a/packages/spellcheck-frontend/lib/tooltip.ts
+++ b/packages/spellcheck-frontend/lib/tooltip.ts
@@ -154,9 +154,14 @@ class SpellcheckTooltipView implements TooltipView {
 
     this.dom = document.createElement('div');
     this.dom.className = 'cm-spellcheck-tooltip';
+    this.dom.tabIndex = -1;
     this.dom.addEventListener('keydown', this.#onTooltipKeydown);
 
     this.#initializeContent(view);
+    // Ensure keyboard events reach the active tooltip regardless of how it was opened.
+    queueMicrotask(() => {
+      this.dom.focus({ preventScroll: true });
+    });
   }
 
   #initializeContent(view: EditorView): void {

--- a/packages/spellcheck-frontend/lib/tooltip.ts
+++ b/packages/spellcheck-frontend/lib/tooltip.ts
@@ -42,6 +42,51 @@ export const spellcheckActions = Facet.define<
 // Tooltip state management using a StateField
 export const setTooltip = StateEffect.define<Tooltip | null>();
 
+const spellcheckTooltipItemSelector = '.cm-spellcheck-tooltip-item';
+
+function getTooltipElement(view: EditorView): HTMLElement | null {
+  return view.dom.closest('.cm-editor')?.querySelector('.cm-spellcheck-tooltip');
+}
+
+function moveTooltipFocus(
+  container: ParentNode,
+  direction: 'up' | 'down',
+): boolean {
+  const items = Array.from(
+    container.querySelectorAll<HTMLButtonElement>(spellcheckTooltipItemSelector),
+  );
+  if (items.length === 0) {
+    return false;
+  }
+
+  const activeElement = container.ownerDocument.activeElement;
+  const currentIndex = items.findIndex((item) => item === activeElement);
+  const delta = direction === 'down' ? 1 : -1;
+  const fallbackIndex = direction === 'down' ? 0 : items.length - 1;
+  const nextIndex =
+    currentIndex === -1
+      ? fallbackIndex
+      : (currentIndex + delta + items.length) % items.length;
+
+  const nextItem = items[nextIndex];
+  if (!nextItem) {
+    return false;
+  }
+  nextItem.focus({ preventScroll: true });
+  return true;
+}
+
+function moveTooltipFocusFromEditor(
+  view: EditorView,
+  direction: 'up' | 'down',
+): boolean {
+  const tooltipElement = getTooltipElement(view);
+  if (!tooltipElement) {
+    return false;
+  }
+  return moveTooltipFocus(tooltipElement, direction);
+}
+
 // Class that implements TooltipView to manage spellcheck tooltip content
 class SpellcheckTooltipView implements TooltipView {
   public readonly dom: HTMLElement;
@@ -51,6 +96,16 @@ class SpellcheckTooltipView implements TooltipView {
   readonly #fetchSuggestions:
     | ((word: string) => Promise<Suggestion[]>)
     | undefined;
+  readonly #onTooltipKeydown = (event: KeyboardEvent): void => {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+      return;
+    }
+    const direction = event.key === 'ArrowDown' ? 'down' : 'up';
+    if (moveTooltipFocus(this.dom, direction)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
 
   constructor(
     issue: SpellcheckIssue,
@@ -66,6 +121,7 @@ class SpellcheckTooltipView implements TooltipView {
 
     this.dom = document.createElement('div');
     this.dom.className = 'cm-spellcheck-tooltip';
+    this.dom.addEventListener('keydown', this.#onTooltipKeydown);
 
     this.#initializeContent(view);
   }
@@ -245,6 +301,10 @@ class SpellcheckTooltipView implements TooltipView {
     // Close tooltip
     view.dispatch({ effects: setTooltip.of(null) });
   }
+
+  destroy(): void {
+    this.dom.removeEventListener('keydown', this.#onTooltipKeydown);
+  }
 }
 
 export const tooltipState = StateField.define<Tooltip | null>({
@@ -348,6 +408,26 @@ export const closeTooltipHandlers = [
     },
   }),
   keymap.of([
+    {
+      key: 'ArrowDown',
+      run: (view) => {
+        const tooltip = view.state.field(tooltipState);
+        if (!tooltip) {
+          return false;
+        }
+        return moveTooltipFocusFromEditor(view, 'down');
+      },
+    },
+    {
+      key: 'ArrowUp',
+      run: (view) => {
+        const tooltip = view.state.field(tooltipState);
+        if (!tooltip) {
+          return false;
+        }
+        return moveTooltipFocusFromEditor(view, 'up');
+      },
+    },
     {
       key: 'Escape',
       run: (view) => {

--- a/packages/spellcheck-frontend/lib/tooltip.ts
+++ b/packages/spellcheck-frontend/lib/tooltip.ts
@@ -44,6 +44,8 @@ export const setTooltip = StateEffect.define<Tooltip | null>();
 
 const spellcheckTooltipItemSelector = '.cm-spellcheck-tooltip-item';
 
+// Resolve the active tooltip element for the current editor.
+// Tooltip DOM can live outside the main editor content subtree.
 function getTooltipElement(view: EditorView): HTMLElement | null {
   const localTooltip = view.dom
     .closest('.cm-editor')
@@ -56,6 +58,7 @@ function getTooltipElement(view: EditorView): HTMLElement | null {
   );
 }
 
+// Cycle focus across interactive tooltip items (actions + suggestions).
 function moveTooltipFocus(
   container: HTMLElement,
   direction: 'up' | 'down',
@@ -86,6 +89,7 @@ function moveTooltipFocus(
   return true;
 }
 
+// Let editor keybindings drive tooltip focus while tooltip is open.
 function moveTooltipFocusFromEditor(
   view: EditorView,
   direction: 'up' | 'down',
@@ -97,6 +101,7 @@ function moveTooltipFocusFromEditor(
   return moveTooltipFocus(tooltipElement, direction);
 }
 
+// Activate the currently focused tooltip item (Enter behavior).
 function activateFocusedTooltipItem(container: HTMLElement): boolean {
   const activeElement = container.ownerDocument.activeElement;
   if (!(activeElement instanceof HTMLButtonElement)) {
@@ -109,6 +114,7 @@ function activateFocusedTooltipItem(container: HTMLElement): boolean {
   return true;
 }
 
+// Return focus to the editor so typing resumes after tooltip interaction.
 function focusEditor(view: EditorView): void {
   queueMicrotask(() => {
     view.focus();
@@ -124,6 +130,7 @@ class SpellcheckTooltipView implements TooltipView {
   readonly #fetchSuggestions:
     | ((word: string) => Promise<Suggestion[]>)
     | undefined;
+  // Keyboard handling when focus is already inside the tooltip.
   readonly #onTooltipKeydown = (event: KeyboardEvent): void => {
     if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
       if (event.key !== 'Enter') {
@@ -156,11 +163,12 @@ class SpellcheckTooltipView implements TooltipView {
 
     this.dom = document.createElement('div');
     this.dom.className = 'cm-spellcheck-tooltip';
+    // Make the tooltip focusable so navigation can start immediately on open.
     this.dom.tabIndex = -1;
     this.dom.addEventListener('keydown', this.#onTooltipKeydown);
 
     this.#initializeContent(view);
-    // Ensure keyboard events reach the active tooltip regardless of how it was opened.
+    // Ensure keyboard events reach the active tooltip regardless of open path.
     queueMicrotask(() => {
       this.dom.focus({ preventScroll: true });
     });
@@ -432,7 +440,11 @@ export const spellcheckKeymap = keymap.of([
   },
 ]);
 
-// Close tooltip on click outside or escape key
+// Shared tooltip behavior while open:
+// - close when clicking outside
+// - ArrowUp/ArrowDown navigation from editor keymap
+// - Enter activation of focused item
+// - Escape close
 export const tooltipHandlers = [
   EditorView.domEventHandlers({
     mousedown(event, view) {

--- a/packages/spellcheck-frontend/lib/tooltip.ts
+++ b/packages/spellcheck-frontend/lib/tooltip.ts
@@ -95,6 +95,18 @@ function moveTooltipFocusFromEditor(
   return moveTooltipFocus(tooltipElement, direction);
 }
 
+function activateFocusedTooltipItem(container: HTMLElement): boolean {
+  const activeElement = container.ownerDocument.activeElement;
+  if (!(activeElement instanceof HTMLButtonElement)) {
+    return false;
+  }
+  if (!activeElement.matches(spellcheckTooltipItemSelector)) {
+    return false;
+  }
+  activeElement.click();
+  return true;
+}
+
 function focusEditor(view: EditorView): void {
   queueMicrotask(() => {
     view.focus();
@@ -112,6 +124,13 @@ class SpellcheckTooltipView implements TooltipView {
     | undefined;
   readonly #onTooltipKeydown = (event: KeyboardEvent): void => {
     if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+      if (event.key !== 'Enter') {
+        return;
+      }
+      if (activateFocusedTooltipItem(this.dom)) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
       return;
     }
     const direction = event.key === 'ArrowDown' ? 'down' : 'up';
@@ -425,37 +444,51 @@ export const closeTooltipHandlers = [
   }),
   Prec.highest(
     keymap.of([
-    {
-      key: 'ArrowDown',
-      run: (view) => {
-        const tooltip = view.state.field(tooltipState);
-        if (!tooltip) {
+      {
+        key: 'ArrowDown',
+        run: (view) => {
+          const tooltip = view.state.field(tooltipState);
+          if (!tooltip) {
+            return false;
+          }
+          return moveTooltipFocusFromEditor(view, 'down');
+        },
+      },
+      {
+        key: 'ArrowUp',
+        run: (view) => {
+          const tooltip = view.state.field(tooltipState);
+          if (!tooltip) {
+            return false;
+          }
+          return moveTooltipFocusFromEditor(view, 'up');
+        },
+      },
+      {
+        key: 'Enter',
+        run: (view) => {
+          const tooltip = view.state.field(tooltipState);
+          if (!tooltip) {
+            return false;
+          }
+          const tooltipElement = getTooltipElement(view);
+          if (!tooltipElement) {
+            return false;
+          }
+          return activateFocusedTooltipItem(tooltipElement);
+        },
+      },
+      {
+        key: 'Escape',
+        run: (view) => {
+          const tooltip = view.state.field(tooltipState);
+          if (tooltip) {
+            view.dispatch({ effects: setTooltip.of(null) });
+            return true;
+          }
           return false;
-        }
-        return moveTooltipFocusFromEditor(view, 'down');
+        },
       },
-    },
-    {
-      key: 'ArrowUp',
-      run: (view) => {
-        const tooltip = view.state.field(tooltipState);
-        if (!tooltip) {
-          return false;
-        }
-        return moveTooltipFocusFromEditor(view, 'up');
-      },
-    },
-    {
-      key: 'Escape',
-      run: (view) => {
-        const tooltip = view.state.field(tooltipState);
-        if (tooltip) {
-          view.dispatch({ effects: setTooltip.of(null) });
-          return true;
-        }
-        return false;
-      },
-    },
     ]),
   ),
 ];

--- a/packages/spellcheck-frontend/lib/tooltip.ts
+++ b/packages/spellcheck-frontend/lib/tooltip.ts
@@ -44,32 +44,6 @@ export const setTooltip = StateEffect.define<Tooltip | null>();
 
 const spellcheckTooltipItemSelector = '.cm-spellcheck-tooltip-item';
 
-function emitDebugLog(
-  hypothesisId: string,
-  location: string,
-  message: string,
-  data: Record<string, unknown>,
-): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
-  const payload = {
-    hypothesisId,
-    location,
-    message,
-    data,
-    timestamp: Date.now(),
-  };
-  void fetch('/__spellcheck_debug_log', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-    keepalive: true,
-  }).catch(() => {
-    // Debug logging should not affect editor behavior.
-  });
-}
-
 function getTooltipElement(view: EditorView): HTMLElement | null {
   const localTooltip = view.dom
     .closest('.cm-editor')
@@ -89,21 +63,11 @@ function moveTooltipFocus(
   const items = Array.from(
     container.querySelectorAll<HTMLButtonElement>(spellcheckTooltipItemSelector),
   );
-  const activeElement = container.ownerDocument.activeElement as HTMLElement | null;
-  const activeElementClass = activeElement?.className;
-  // #region agent log
-  emitDebugLog('H3', 'tooltip.ts:moveTooltipFocus:entry', 'focus-move-entry', {
-    direction,
-    itemsCount: items.length,
-    activeTag: activeElement?.tagName ?? null,
-    activeClass:
-      typeof activeElementClass === 'string' ? activeElementClass : null,
-  });
-  // #endregion
   if (items.length === 0) {
     return false;
   }
 
+  const activeElement = container.ownerDocument.activeElement;
   const currentIndex = items.findIndex((item) => item === activeElement);
   const delta = direction === 'down' ? 1 : -1;
   const fallbackIndex = direction === 'down' ? 0 : items.length - 1;
@@ -117,15 +81,6 @@ function moveTooltipFocus(
     return false;
   }
   nextItem.focus({ preventScroll: true });
-  // #region agent log
-  emitDebugLog('H3', 'tooltip.ts:moveTooltipFocus:exit', 'focus-move-exit', {
-    direction,
-    currentIndex,
-    nextIndex,
-    focusedText: nextItem.textContent ?? null,
-    activeTagAfter: container.ownerDocument.activeElement?.tagName ?? null,
-  });
-  // #endregion
   return true;
 }
 
@@ -134,19 +89,6 @@ function moveTooltipFocusFromEditor(
   direction: 'up' | 'down',
 ): boolean {
   const tooltipElement = getTooltipElement(view);
-  // #region agent log
-  emitDebugLog(
-    'H2',
-    'tooltip.ts:moveTooltipFocusFromEditor',
-    'editor-to-tooltip-lookup',
-    {
-      direction,
-      tooltipFound: Boolean(tooltipElement),
-      tooltipStatePresent: Boolean(view.state.field(tooltipState)),
-      activeTag: view.dom.ownerDocument.activeElement?.tagName ?? null,
-    },
-  );
-  // #endregion
   if (!tooltipElement) {
     return false;
   }
@@ -163,13 +105,6 @@ class SpellcheckTooltipView implements TooltipView {
     | ((word: string) => Promise<Suggestion[]>)
     | undefined;
   readonly #onTooltipKeydown = (event: KeyboardEvent): void => {
-    // #region agent log
-    emitDebugLog('H4', 'tooltip.ts:onTooltipKeydown', 'tooltip-dom-keydown', {
-      key: event.key,
-      defaultPrevented: event.defaultPrevented,
-      activeTag: this.dom.ownerDocument.activeElement?.tagName ?? null,
-    });
-    // #endregion
     if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
       return;
     }
@@ -453,14 +388,6 @@ export const contextMenuHandler = EditorView.domEventHandlers({
 // Ctrl+. keyboard shortcut handler
 const showSuggestionsCommand: Command = (view) => {
   const pos = view.state.selection.main.head;
-  // #region agent log
-  emitDebugLog(
-    'H5',
-    'tooltip.ts:showSuggestionsCommand',
-    'ctrl-dot-invoked',
-    { selectionHead: pos },
-  );
-  // #endregion
   return showSpellcheckTooltip(view, pos);
 };
 
@@ -474,21 +401,6 @@ export const spellcheckKeymap = keymap.of([
 // Close tooltip on click outside or escape key
 export const closeTooltipHandlers = [
   EditorView.domEventHandlers({
-    keydown(event, view) {
-      const tooltip = view.state.field(tooltipState);
-      if (!tooltip) {
-        return false;
-      }
-      // #region agent log
-      emitDebugLog('H1', 'tooltip.ts:editorDomKeydown', 'editor-dom-keydown', {
-        key: event.key,
-        defaultPrevented: event.defaultPrevented,
-        eventTargetTag: (event.target as HTMLElement | null)?.tagName ?? null,
-        activeTag: view.dom.ownerDocument.activeElement?.tagName ?? null,
-      });
-      // #endregion
-      return false;
-    },
     mousedown(event, view) {
       // Don't close if clicking inside the tooltip
       const target = event.target as HTMLElement;
@@ -509,12 +421,6 @@ export const closeTooltipHandlers = [
       key: 'ArrowDown',
       run: (view) => {
         const tooltip = view.state.field(tooltipState);
-        // #region agent log
-        emitDebugLog('H1', 'tooltip.ts:keymapArrowDown', 'keymap-arrow-down', {
-          tooltipPresent: Boolean(tooltip),
-          selectionHead: view.state.selection.main.head,
-        });
-        // #endregion
         if (!tooltip) {
           return false;
         }
@@ -525,12 +431,6 @@ export const closeTooltipHandlers = [
       key: 'ArrowUp',
       run: (view) => {
         const tooltip = view.state.field(tooltipState);
-        // #region agent log
-        emitDebugLog('H1', 'tooltip.ts:keymapArrowUp', 'keymap-arrow-up', {
-          tooltipPresent: Boolean(tooltip),
-          selectionHead: view.state.selection.main.head,
-        });
-        // #endregion
         if (!tooltip) {
           return false;
         }

--- a/packages/spellcheck-frontend/lib/tooltip.ts
+++ b/packages/spellcheck-frontend/lib/tooltip.ts
@@ -44,6 +44,32 @@ export const setTooltip = StateEffect.define<Tooltip | null>();
 
 const spellcheckTooltipItemSelector = '.cm-spellcheck-tooltip-item';
 
+function emitDebugLog(
+  hypothesisId: string,
+  location: string,
+  message: string,
+  data: Record<string, unknown>,
+): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const payload = {
+    hypothesisId,
+    location,
+    message,
+    data,
+    timestamp: Date.now(),
+  };
+  void fetch('/__spellcheck_debug_log', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    keepalive: true,
+  }).catch(() => {
+    // Debug logging should not affect editor behavior.
+  });
+}
+
 function getTooltipElement(view: EditorView): HTMLElement | null {
   const localTooltip = view.dom
     .closest('.cm-editor')
@@ -63,11 +89,21 @@ function moveTooltipFocus(
   const items = Array.from(
     container.querySelectorAll<HTMLButtonElement>(spellcheckTooltipItemSelector),
   );
+  const activeElement = container.ownerDocument.activeElement as HTMLElement | null;
+  const activeElementClass = activeElement?.className;
+  // #region agent log
+  emitDebugLog('H3', 'tooltip.ts:moveTooltipFocus:entry', 'focus-move-entry', {
+    direction,
+    itemsCount: items.length,
+    activeTag: activeElement?.tagName ?? null,
+    activeClass:
+      typeof activeElementClass === 'string' ? activeElementClass : null,
+  });
+  // #endregion
   if (items.length === 0) {
     return false;
   }
 
-  const activeElement = container.ownerDocument.activeElement;
   const currentIndex = items.findIndex((item) => item === activeElement);
   const delta = direction === 'down' ? 1 : -1;
   const fallbackIndex = direction === 'down' ? 0 : items.length - 1;
@@ -81,6 +117,15 @@ function moveTooltipFocus(
     return false;
   }
   nextItem.focus({ preventScroll: true });
+  // #region agent log
+  emitDebugLog('H3', 'tooltip.ts:moveTooltipFocus:exit', 'focus-move-exit', {
+    direction,
+    currentIndex,
+    nextIndex,
+    focusedText: nextItem.textContent ?? null,
+    activeTagAfter: container.ownerDocument.activeElement?.tagName ?? null,
+  });
+  // #endregion
   return true;
 }
 
@@ -89,6 +134,19 @@ function moveTooltipFocusFromEditor(
   direction: 'up' | 'down',
 ): boolean {
   const tooltipElement = getTooltipElement(view);
+  // #region agent log
+  emitDebugLog(
+    'H2',
+    'tooltip.ts:moveTooltipFocusFromEditor',
+    'editor-to-tooltip-lookup',
+    {
+      direction,
+      tooltipFound: Boolean(tooltipElement),
+      tooltipStatePresent: Boolean(view.state.field(tooltipState)),
+      activeTag: view.dom.ownerDocument.activeElement?.tagName ?? null,
+    },
+  );
+  // #endregion
   if (!tooltipElement) {
     return false;
   }
@@ -105,6 +163,13 @@ class SpellcheckTooltipView implements TooltipView {
     | ((word: string) => Promise<Suggestion[]>)
     | undefined;
   readonly #onTooltipKeydown = (event: KeyboardEvent): void => {
+    // #region agent log
+    emitDebugLog('H4', 'tooltip.ts:onTooltipKeydown', 'tooltip-dom-keydown', {
+      key: event.key,
+      defaultPrevented: event.defaultPrevented,
+      activeTag: this.dom.ownerDocument.activeElement?.tagName ?? null,
+    });
+    // #endregion
     if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
       return;
     }
@@ -388,6 +453,14 @@ export const contextMenuHandler = EditorView.domEventHandlers({
 // Ctrl+. keyboard shortcut handler
 const showSuggestionsCommand: Command = (view) => {
   const pos = view.state.selection.main.head;
+  // #region agent log
+  emitDebugLog(
+    'H5',
+    'tooltip.ts:showSuggestionsCommand',
+    'ctrl-dot-invoked',
+    { selectionHead: pos },
+  );
+  // #endregion
   return showSpellcheckTooltip(view, pos);
 };
 
@@ -401,6 +474,21 @@ export const spellcheckKeymap = keymap.of([
 // Close tooltip on click outside or escape key
 export const closeTooltipHandlers = [
   EditorView.domEventHandlers({
+    keydown(event, view) {
+      const tooltip = view.state.field(tooltipState);
+      if (!tooltip) {
+        return false;
+      }
+      // #region agent log
+      emitDebugLog('H1', 'tooltip.ts:editorDomKeydown', 'editor-dom-keydown', {
+        key: event.key,
+        defaultPrevented: event.defaultPrevented,
+        eventTargetTag: (event.target as HTMLElement | null)?.tagName ?? null,
+        activeTag: view.dom.ownerDocument.activeElement?.tagName ?? null,
+      });
+      // #endregion
+      return false;
+    },
     mousedown(event, view) {
       // Don't close if clicking inside the tooltip
       const target = event.target as HTMLElement;
@@ -421,6 +509,12 @@ export const closeTooltipHandlers = [
       key: 'ArrowDown',
       run: (view) => {
         const tooltip = view.state.field(tooltipState);
+        // #region agent log
+        emitDebugLog('H1', 'tooltip.ts:keymapArrowDown', 'keymap-arrow-down', {
+          tooltipPresent: Boolean(tooltip),
+          selectionHead: view.state.selection.main.head,
+        });
+        // #endregion
         if (!tooltip) {
           return false;
         }
@@ -431,6 +525,12 @@ export const closeTooltipHandlers = [
       key: 'ArrowUp',
       run: (view) => {
         const tooltip = view.state.field(tooltipState);
+        // #region agent log
+        emitDebugLog('H1', 'tooltip.ts:keymapArrowUp', 'keymap-arrow-up', {
+          tooltipPresent: Boolean(tooltip),
+          selectionHead: view.state.selection.main.head,
+        });
+        // #endregion
         if (!tooltip) {
           return false;
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Enable keyboard-first spellcheck dropdown interaction and keep editor focus stable after accepting a suggestion.

## What changed
- Added `ArrowUp`/`ArrowDown` cycling for active spellcheck tooltip items.
- Added visible keyboard focus styling for tooltip items.
- Added explicit `Enter` handling on focused tooltip items so Enter activates the focused action/suggestion.
- After selection/action, editor focus is restored and caret remains at the replacement end.
- Focus the tooltip container when it opens so keyboard navigation works consistently regardless of trigger path (`Ctrl+.` or right-click).
- Removed the temporary demo alias override in `apps/demo/vite.config.ts`.
- Added `.changeset/spellcheck-tooltip-keyboard-nav.md` as a patch changeset for `@prosemark/spellcheck-frontend`.
- Added inline maintainer comments in `packages/spellcheck-frontend/lib/tooltip.ts` describing helper/component roles.

## Walkthrough artifacts
[spellcheck_ctrl_dot_right_click_navigation_fix_demo.mp4](https://cursor.com/agents/bc-b5b11112-a1af-4d97-98d0-8ad8991a3720/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspellcheck_ctrl_dot_right_click_navigation_fix_demo.mp4)
[spellcheck_enter_focus_followup.webm](https://cursor.com/agents/bc-b5b11112-a1af-4d97-98d0-8ad8991a3720/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspellcheck_enter_focus_followup.webm)
[Both trigger paths regression screenshot](https://cursor.com/agents/bc-b5b11112-a1af-4d97-98d0-8ad8991a3720/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspellcheck_popup_both_flows.png)
[Enter keeps focus at word end](https://cursor.com/agents/bc-b5b11112-a1af-4d97-98d0-8ad8991a3720/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspellcheck_enter_focus_followup.png)
[spellcheck_ctrl_dot_right_click_regression.txt](https://cursor.com/agents/bc-b5b11112-a1af-4d97-98d0-8ad8991a3720/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspellcheck_ctrl_dot_right_click_regression.txt)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->