### PR TITLE
Implement widget eq() to prevent unnecessary rerenders

### DIFF
--- a/.changeset/ninety-pigs-chew.md
+++ b/.changeset/ninety-pigs-chew.md
@@ -1,0 +1,6 @@
+---
+'@prosemark/core': patch
+'@prosemark/render-html': patch
+---
+
+Add `eq()` methods to widget classes so unchanged widgets can reuse existing DOM nodes instead of re-rendering on unrelated editor updates. This reduces unnecessary widget churn and avoids repeated failed-image reload attempts when cursor movement does not change widget content.

--- a/packages/core/lib/blockQuote.ts
+++ b/packages/core/lib/blockQuote.ts
@@ -14,6 +14,10 @@ class NestedBlockQuoteBorder extends WidgetType {
     super();
   }
 
+  eq(other: NestedBlockQuoteBorder): boolean {
+    return this.offset === other.offset;
+  }
+
   toDOM() {
     const span = document.createElement('span');
     span.className = 'cm-nested-blockquote-border';

--- a/packages/core/lib/fold/bulletList.ts
+++ b/packages/core/lib/fold/bulletList.ts
@@ -2,6 +2,10 @@ import { Decoration, WidgetType } from '@codemirror/view';
 import { foldableSyntaxFacet } from './core';
 
 class BulletPoint extends WidgetType {
+  eq(other: BulletPoint): boolean {
+    return other instanceof BulletPoint;
+  }
+
   toDOM() {
     const span = document.createElement('span');
     span.className = 'cm-rendered-list-mark';

--- a/packages/core/lib/fold/dashes.ts
+++ b/packages/core/lib/fold/dashes.ts
@@ -28,6 +28,10 @@ class DashWidget extends WidgetType {
         super();
     }
 
+    eq(other: DashWidget): boolean {
+        return this.dashCount === other.dashCount;
+    }
+
     toDOM() {
         const span = document.createElement("span");
         span.className = "cm-dash";

--- a/packages/core/lib/fold/emoji.ts
+++ b/packages/core/lib/fold/emoji.ts
@@ -42,6 +42,10 @@ class EmojiWidget extends WidgetType {
     super();
   }
 
+  eq(other: EmojiWidget): boolean {
+    return this.emoji === other.emoji;
+  }
+
   toDOM() {
     const span = document.createElement('span');
     span.className = 'cm-emoji';

--- a/packages/core/lib/fold/horizontalRule.ts
+++ b/packages/core/lib/fold/horizontalRule.ts
@@ -5,6 +5,10 @@ import {
 } from './core';
 
 class HorizontalRuleWidget extends WidgetType {
+  eq(other: HorizontalRuleWidget): boolean {
+    return other instanceof HorizontalRuleWidget;
+  }
+
   toDOM() {
     const div = document.createElement('div');
     div.className = 'cm-horizontal-rule-container';

--- a/packages/core/lib/fold/image.ts
+++ b/packages/core/lib/fold/image.ts
@@ -13,13 +13,19 @@ class ImageWidget extends WidgetType {
     super();
   }
 
+  eq(other: ImageWidget): boolean {
+    return this.url === other.url && this.block === other.block;
+  }
+
   toDOM() {
     const elem = document.createElement(this.block ? 'div' : 'span');
     elem.className = 'cm-image';
     if (this.block) {
       elem.className += ' cm-image-block';
     }
-    elem.innerHTML = `<img src="${this.url}" />`;
+    const image = document.createElement('img');
+    image.src = this.url;
+    elem.appendChild(image);
     return elem;
   }
 

--- a/packages/core/lib/fold/task.ts
+++ b/packages/core/lib/fold/task.ts
@@ -10,6 +10,10 @@ class Checkbox extends WidgetType {
     this.value = value;
   }
 
+  eq(other: Checkbox): boolean {
+    return this.value === other.value;
+  }
+
   toDOM() {
     const el = document.createElement('input');
     el.type = 'checkbox';

--- a/packages/render-html/lib/main.ts
+++ b/packages/render-html/lib/main.ts
@@ -12,6 +12,10 @@ class HTMLWidget extends WidgetType {
     super();
   }
 
+  eq(other: HTMLWidget): boolean {
+    return this.value === other.value;
+  }
+
   toDOM() {
     const el = document.createElement('div');
     el.className = 'cm-html-widget';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implement `eq()` for `ImageWidget` to prevent missing images from repeatedly reloading and causing layout shifts on cursor movement.

Previously, CodeMirror would re-create the image widget on every selection-only update (like cursor movement or typing). By implementing `eq()`, CodeMirror now reuses the existing DOM node for the image, stopping unnecessary reloads of failed image requests.

<div><a href="https://cursor.com/agents/bc-a1c6c962-71e5-4628-8bff-d41b7fca5d5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1c6c962-71e5-4628-8bff-d41b7fca5d5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->