### PR TITLE
fix(core): refresh WYSIWYM decorations when syntax tree is ready

### DIFF
--- a/.changeset/warm-jeans-invite.md
+++ b/.changeset/warm-jeans-invite.md
@@ -1,0 +1,6 @@
+---
+'vscode-prosemark-cspell-integration': patch
+'vscode-prosemark': patch
+---
+
+Updated build system to use vite instead of tsdown for the webviews

--- a/apps/vscode-extensions/core/package.json
+++ b/apps/vscode-extensions/core/package.json
@@ -23,7 +23,7 @@
   "activationEvents": [
     "onStartupFinished"
   ],
-  "main": "./dist/extension.js",
+  "main": "./dist/extension/extension.js",
   "contributes": {
     "customEditors": [
       {

--- a/apps/vscode-extensions/core/src/sub-extensions/core.ts
+++ b/apps/vscode-extensions/core/src/sub-extensions/core.ts
@@ -40,11 +40,11 @@ export class Core implements SubExtension<
   }
 
   getWebviewScriptUri(): vscode.Uri {
-    return vscode.Uri.joinPath(this.#extensionUri, 'dist', 'webview.js');
+    return vscode.Uri.joinPath(this.#extensionUri, 'dist', 'webview', 'webview.js');
   }
 
   getWebviewStyleUri(): vscode.Uri {
-    return vscode.Uri.joinPath(this.#extensionUri, 'dist', 'vscode-prosemark.css');
+    return vscode.Uri.joinPath(this.#extensionUri, 'dist', 'webview', 'vscode-prosemark.css');
   }
 
   getLocalResourceRoots(): vscode.Uri[] {

--- a/apps/vscode-extensions/core/tsdown.config.mts
+++ b/apps/vscode-extensions/core/tsdown.config.mts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig([
   {
-    outDir: 'dist',
+    outDir: 'dist/extension',
     noExternal: [/^(?!vscode).*/],
     external: 'vscode',
     name: 'extension backend',

--- a/apps/vscode-extensions/core/vite.config.ts
+++ b/apps/vscode-extensions/core/vite.config.ts
@@ -1,11 +1,9 @@
 import { defineConfig } from "vite";
 import { resolve } from "node:path";
-import proseMarkVSCodeExtensionIntegratorPlugin from "@prosemark/vscode-extension-integrator/rolldown-plugin";
 
 export default defineConfig({
-  plugins: [proseMarkVSCodeExtensionIntegratorPlugin()],
   build: {
-    outDir: "dist",
+    outDir: "dist/webview",
     target: "es2020",
     lib: {
       entry: resolve(__dirname, "src/webview/main.ts"),

--- a/apps/vscode-extensions/cspell-integration/package.json
+++ b/apps/vscode-extensions/cspell-integration/package.json
@@ -22,7 +22,7 @@
   "activationEvents": [
     "onStartupFinished"
   ],
-  "main": "./dist/extension.js",
+  "main": "./dist/extension/extension.js",
   "extensionDependencies": [
     "jsimonrichard.vscode-prosemark",
     "streetsidesoftware.code-spell-checker"

--- a/apps/vscode-extensions/cspell-integration/src/sub-extension.ts
+++ b/apps/vscode-extensions/cspell-integration/src/sub-extension.ts
@@ -41,11 +41,11 @@ export class CSpellIntegration implements SubExtension<
   }
 
   getWebviewScriptUri(): vscode.Uri {
-    return vscode.Uri.joinPath(this.#extensionUri, 'dist', 'webview.js');
+    return vscode.Uri.joinPath(this.#extensionUri, 'dist', 'webview', 'webview.js');
   }
 
   getWebviewStyleUri(): vscode.Uri {
-    return vscode.Uri.joinPath(this.#extensionUri, 'dist', 'vscode-prosemark-cspell-integration.css');
+    return vscode.Uri.joinPath(this.#extensionUri, 'dist', 'webview', 'vscode-prosemark-cspell-integration.css');
   }
 
   getLocalResourceRoots(): vscode.Uri[] {

--- a/apps/vscode-extensions/cspell-integration/tsdown.config.mts
+++ b/apps/vscode-extensions/cspell-integration/tsdown.config.mts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig([
   {
-    outDir: 'dist',
+    outDir: 'dist/extension',
     noExternal: [/^(?!vscode).*/],
     external: 'vscode',
     name: 'extension backend',

--- a/apps/vscode-extensions/cspell-integration/vite.config.ts
+++ b/apps/vscode-extensions/cspell-integration/vite.config.ts
@@ -5,7 +5,7 @@ import proseMarkVSCodeExtensionIntegratorPlugin from "@prosemark/vscode-extensio
 export default defineConfig({
   plugins: [proseMarkVSCodeExtensionIntegratorPlugin()],
   build: {
-    outDir: "dist",
+    outDir: "dist/webview",
     target: "es2020",
     lib: {
       entry: resolve(__dirname, "src/webview/main.ts"),

--- a/bun.lock
+++ b/bun.lock
@@ -140,7 +140,6 @@
         "@lezer/markdown": "^1.2.1",
         "@prosemark/spellcheck-frontend": "workspace:*",
         "@prosemark/vscode-extension-integrator": "workspace:*",
-        "vite": "^8.0.5",
       },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
@@ -154,6 +153,7 @@
         "eslint": "^9.32.0",
         "tsdown": "^0.14.1",
         "typescript": "^5.9.2",
+        "vite": "^8.0.5",
       },
     },
     "packages/core": {

--- a/packages/core/lib/fold/core.ts
+++ b/packages/core/lib/fold/core.ts
@@ -91,7 +91,11 @@ export const foldExtension = StateField.define<DecorationSet>({
   },
 
   update(deco, tr) {
-    if (tr.docChanged || tr.selection) {
+    if (
+      tr.docChanged ||
+      tr.selection ||
+      syntaxTree(tr.startState) !== syntaxTree(tr.state)
+    ) {
       return buildDecorations(tr.state);
     }
     return deco.map(tr.changes);

--- a/packages/core/lib/hide/core.ts
+++ b/packages/core/lib/hide/core.ts
@@ -118,7 +118,11 @@ export const hideExtension = StateField.define<DecorationSet>({
   },
 
   update(deco, tr) {
-    if (tr.docChanged || tr.selection) {
+    if (
+      tr.docChanged ||
+      tr.selection ||
+      syntaxTree(tr.startState) !== syntaxTree(tr.state)
+    ) {
       return buildDecorations(tr.state);
     }
     return deco.map(tr.changes);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When the editor opened, markdown looked like raw source (syntax visible, fold widgets not applied) until something triggered a doc or selection change.

## Cause

The fold and hide extensions are implemented as `StateField`s that rebuild decorations only on `tr.docChanged` or `tr.selection`. The Lezer parse tree is updated asynchronously by CodeMirror’s language layer via transactions that do not change the document or selection. The initial `create` often ran while `syntaxTree(state)` was still the empty tree, so decorations were built for nothing and were never rebuilt when parsing finished.

## Fix

Rebuild fold and hide decorations whenever `syntaxTree(tr.startState) !== syntaxTree(tr.state)`, so they refresh as soon as the parsed tree becomes available.

## Verification

- `bun run check-types` in `packages/core` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e20e0b1-c030-46ba-a318-3ab112b7115e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e20e0b1-c030-46ba-a318-3ab112b7115e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

