### PR TITLE
Markdown formatting keybinds, changeset, and Cursor changesets rule

### DIFF
--- a/.changeset/markdown-format-keybinds.md
+++ b/.changeset/markdown-format-keybinds.md
@@ -1,0 +1,5 @@
+---
+"@prosemark/core": patch
+---
+
+Add Markdown formatting shortcuts to `prosemarkBasicSetup`: Mod-b (bold), Mod-i (italic), Mod-backtick (inline code), Mod-k (link with prompt for URL), Mod-u (HTML `<u>` underline), and Mod-Shift-x (strikethrough when GFM is enabled). Export `prosemarkMarkdownFormattingKeymap` and `prosemarkMarkdownFormattingKeymapExtension` for custom setups.

--- a/.changeset/markdown-format-keybinds.md
+++ b/.changeset/markdown-format-keybinds.md
@@ -2,4 +2,4 @@
 "@prosemark/core": patch
 ---
 
-Add Markdown formatting shortcuts to `prosemarkBasicSetup`: Mod-b (bold), Mod-i (italic), Mod-backtick (inline code), Mod-k (wrap selection as link label in `[text]()` with the cursor in the URL), and Mod-Shift-x (strikethrough when GFM is enabled). Export `prosemarkMarkdownFormattingKeymap` and `prosemarkMarkdownFormattingKeymapExtension` for custom setups.
+Add Markdown formatting shortcuts to `prosemarkBasicSetup`: Mod-b (bold), Mod-i (italic with `_` delimiters), Mod-backtick (inline code), Mod-k (wrap selection as link label in `[text]()` with the cursor in the URL), and Mod-Shift-x (strikethrough when GFM is enabled). Export `prosemarkMarkdownFormattingKeymap` and `prosemarkMarkdownFormattingKeymapExtension` for custom setups.

--- a/.changeset/markdown-format-keybinds.md
+++ b/.changeset/markdown-format-keybinds.md
@@ -2,4 +2,4 @@
 "@prosemark/core": patch
 ---
 
-Add Markdown formatting shortcuts to `prosemarkBasicSetup`: Mod-b (bold), Mod-i (italic), Mod-backtick (inline code), Mod-k (link with prompt for URL), Mod-u (HTML `<u>` underline), and Mod-Shift-x (strikethrough when GFM is enabled). Export `prosemarkMarkdownFormattingKeymap` and `prosemarkMarkdownFormattingKeymapExtension` for custom setups.
+Add Markdown formatting shortcuts to `prosemarkBasicSetup`: Mod-b (bold), Mod-i (italic), Mod-backtick (inline code), Mod-k (wrap selection as link label in `[text]()` with the cursor in the URL), and Mod-Shift-x (strikethrough when GFM is enabled). Export `prosemarkMarkdownFormattingKeymap` and `prosemarkMarkdownFormattingKeymapExtension` for custom setups.

--- a/.cursor/rules/changesets.mdc
+++ b/.cursor/rules/changesets.mdc
@@ -1,0 +1,26 @@
+---
+description: How to record user-facing package changes for releases
+globs:
+  - "**/*"
+---
+
+# Changesets (release notes)
+
+This repo uses [Changesets](https://github.com/changesets/changesets). **Do not** hand-edit per-package `CHANGELOG.md` files for new work: they are updated automatically when releases run.
+
+When a change should appear in the next release notes:
+
+1. Add a new markdown file under `.changeset/` (e.g. `.changeset/some-topic.md`).
+2. Use the standard frontmatter listing affected packages and bump type (`patch`, `minor`, or `major`):
+
+   ```yaml
+   ---
+   "@prosemark/core": patch
+   ---
+   ```
+
+   For multiple packages, list each on its own line under the same `---` block.
+
+3. After the frontmatter, write a concise summary in the imperative or plain past tense, as you want it to read in the changelog.
+
+Remove or avoid duplicate descriptions in `CHANGELOG.md`; rely on the changeset file only.

--- a/packages/core/lib/basicSetup.ts
+++ b/packages/core/lib/basicSetup.ts
@@ -36,6 +36,7 @@ import {
 import { softIndentExtension } from './softIndentExtension';
 import { fixedTabWidthExtension } from './tabWidthExtension';
 import { revealBlockOnArrowExtension } from './revealBlockOnArrow';
+import { prosemarkMarkdownFormattingKeymap } from './markdownFormattingKeymap';
 export { prosemarkMarkdownSyntaxExtensions } from './markdown';
 
 export const prosemarkBasicSetup = (): Extension => [
@@ -57,6 +58,7 @@ export const prosemarkBasicSetup = (): Extension => [
   closeBrackets(),
   autocompletion(),
   keymap.of([
+    ...prosemarkMarkdownFormattingKeymap,
     ...closeBracketsKeymap,
     ...defaultKeymap,
     ...searchKeymap,

--- a/packages/core/lib/main.ts
+++ b/packages/core/lib/main.ts
@@ -10,4 +10,9 @@ export * from './codeFenceExtension';
 
 export * from './basicSetup';
 
+export {
+  prosemarkMarkdownFormattingKeymap,
+  prosemarkMarkdownFormattingKeymapExtension,
+} from './markdownFormattingKeymap';
+
 export { eventHandlersWithClass } from './utils';

--- a/packages/core/lib/markdownFormattingKeymap.ts
+++ b/packages/core/lib/markdownFormattingKeymap.ts
@@ -107,70 +107,21 @@ const toggleEmphasis = makeToggleInlineCommand('Emphasis', '*', '*');
 const toggleInlineCode = makeToggleInlineCommand('InlineCode', '`', '`');
 const toggleStrikethrough = makeToggleInlineCommand('Strikethrough', '~~', '~~');
 
-function toggleUnderlineMarkup(
-  state: EditorState,
-  range: SelectionRange,
-): { range: SelectionRange; changes: ChangeSpec } | null {
-  if (!isMarkdownContext(state, range.from)) return null;
-  const text = state.sliceDoc(range.from, range.to);
-  const open = '<u>';
-  const close = '</u>';
-  if (
-    text.startsWith(open) &&
-    text.endsWith(close) &&
-    text.length >= open.length + close.length
-  ) {
-    const inner = text.slice(open.length, text.length - close.length);
-    return {
-      changes: { from: range.from, to: range.to, insert: inner },
-      range: EditorSelection.range(range.from, range.from + inner.length),
-    };
-  }
-  const innerLen = text.length;
-  return {
-    changes: { from: range.from, to: range.to, insert: open + text + close },
-    range: EditorSelection.range(
-      range.from + open.length,
-      range.from + open.length + innerLen,
-    ),
-  };
-}
-
-const toggleHtmlUnderline: Command = (view) => {
-  const { state } = view;
-  const specs: { range: SelectionRange; changes: ChangeSpec }[] = [];
-  for (const range of state.selection.ranges) {
-    if (!isMarkdownContext(state, range.from)) return false;
-    const spec = toggleUnderlineMarkup(state, range);
-    if (!spec) return false;
-    specs.push(spec);
-  }
-  let i = 0;
-  view.dispatch({
-    ...state.changeByRange(() => specs[i++] as { range: SelectionRange; changes: ChangeSpec }),
-    scrollIntoView: true,
-    userEvent: 'input',
-  });
-  return true;
-};
-
 const insertLink: Command = (view) => {
   const { state } = view;
   for (const range of state.selection.ranges) {
-    if (range.empty || !isMarkdownContext(state, range.from)) return false;
+    if (!isMarkdownContext(state, range.from)) return false;
   }
-  const url =
-    typeof globalThis.prompt === 'function'
-      ? globalThis.prompt('Link URL', 'https://')
-      : null;
-  if (url == null) return false;
   view.dispatch({
     ...state.changeByRange((range) => {
       const label = state.sliceDoc(range.from, range.to);
-      const insert = `[${label}](${url})`;
+      const insert = range.empty ? `[]()` : `[${label}]()`;
+      const head = range.empty
+        ? range.from + 1
+        : range.from + 1 + label.length + 2;
       return {
         changes: { from: range.from, to: range.to, insert },
-        range: EditorSelection.cursor(range.from + insert.length),
+        range: EditorSelection.cursor(head),
       };
     }),
     scrollIntoView: true,
@@ -182,15 +133,13 @@ const insertLink: Command = (view) => {
 /**
  * Key bindings for common rich-text shortcuts in Markdown (Mod = Ctrl on
  * Windows/Linux, Cmd on macOS). Placed ahead of CodeMirror defaults so
- * **Mod-i** and **Mod-u** apply formatting instead of syntax selection /
- * selection undo.
+ * **Mod-i** applies emphasis instead of `selectParentSyntax`.
  */
 export const prosemarkMarkdownFormattingKeymap: readonly KeyBinding[] = [
   { key: 'Mod-b', run: toggleStrongEmphasis, preventDefault: true },
   { key: 'Mod-i', run: toggleEmphasis, preventDefault: true },
   { key: 'Mod-`', run: toggleInlineCode, preventDefault: true },
   { key: 'Mod-k', run: insertLink, preventDefault: true },
-  { key: 'Mod-u', run: toggleHtmlUnderline, preventDefault: true },
   { key: 'Mod-Shift-x', run: toggleStrikethrough, preventDefault: true },
 ];
 

--- a/packages/core/lib/markdownFormattingKeymap.ts
+++ b/packages/core/lib/markdownFormattingKeymap.ts
@@ -1,0 +1,199 @@
+import { markdownLanguage } from '@codemirror/lang-markdown';
+import { syntaxTree } from '@codemirror/language';
+import type { SyntaxNode } from '@lezer/common';
+import {
+  EditorSelection,
+  type ChangeSpec,
+  type EditorState,
+  type Extension,
+  type SelectionRange,
+} from '@codemirror/state';
+import { type Command, type KeyBinding, keymap } from '@codemirror/view';
+
+function isMarkdownContext(state: EditorState, pos: number): boolean {
+  return (
+    markdownLanguage.isActiveAt(state, pos, -1) ||
+    markdownLanguage.isActiveAt(state, pos, 1)
+  );
+}
+
+function findOutermostCoveringNode(
+  state: EditorState,
+  from: number,
+  to: number,
+  predicate: (n: SyntaxNode) => boolean,
+): SyntaxNode | null {
+  const tree = syntaxTree(state);
+  let found: SyntaxNode | null = null;
+  for (let pos = from; pos <= to; pos++) {
+    let node: SyntaxNode | null = tree.resolveInner(pos, 1);
+    while (node) {
+      if (node.to < from || node.from > to) break;
+      if (predicate(node)) {
+        if (!found || node.from < found.from || node.to > found.to) found = node;
+      }
+      node = node.parent;
+    }
+  }
+  return found;
+}
+
+function toggleInlineMarkup(
+  state: EditorState,
+  range: SelectionRange,
+  nodeName: string,
+  open: string,
+  close: string,
+): { range: SelectionRange; changes: ChangeSpec } | null {
+  if (!isMarkdownContext(state, range.from)) return null;
+  const { from, to } = range;
+  const covering = findOutermostCoveringNode(
+    state,
+    from,
+    to,
+    (n) => n.name === nodeName,
+  );
+  if (covering && covering.from <= from && covering.to >= to) {
+    const innerFrom = covering.from + open.length;
+    const innerTo = covering.to - close.length;
+    if (innerFrom > innerTo) return null;
+    const innerLen = innerTo - innerFrom;
+    return {
+      changes: {
+        from: covering.from,
+        to: covering.to,
+        insert: state.sliceDoc(innerFrom, innerTo),
+      },
+      range: EditorSelection.range(covering.from, covering.from + innerLen),
+    };
+  }
+  const text = state.sliceDoc(from, to);
+  const innerLen = text.length;
+  return {
+    changes: { from, to, insert: open + text + close },
+    range: EditorSelection.range(
+      from + open.length,
+      from + open.length + innerLen,
+    ),
+  };
+}
+
+function makeToggleInlineCommand(
+  nodeName: string,
+  open: string,
+  close: string,
+): Command {
+  return (view) => {
+    const { state } = view;
+    const specs: { range: SelectionRange; changes: ChangeSpec }[] = [];
+    for (const range of state.selection.ranges) {
+      if (!isMarkdownContext(state, range.from)) return false;
+      const spec = toggleInlineMarkup(state, range, nodeName, open, close);
+      if (!spec) return false;
+      specs.push(spec);
+    }
+    let i = 0;
+    view.dispatch({
+      ...state.changeByRange(() => specs[i++] as { range: SelectionRange; changes: ChangeSpec }),
+      scrollIntoView: true,
+      userEvent: 'input',
+    });
+    return true;
+  };
+}
+
+const toggleStrongEmphasis = makeToggleInlineCommand('StrongEmphasis', '**', '**');
+const toggleEmphasis = makeToggleInlineCommand('Emphasis', '*', '*');
+const toggleInlineCode = makeToggleInlineCommand('InlineCode', '`', '`');
+const toggleStrikethrough = makeToggleInlineCommand('Strikethrough', '~~', '~~');
+
+function toggleUnderlineMarkup(
+  state: EditorState,
+  range: SelectionRange,
+): { range: SelectionRange; changes: ChangeSpec } | null {
+  if (!isMarkdownContext(state, range.from)) return null;
+  const text = state.sliceDoc(range.from, range.to);
+  const open = '<u>';
+  const close = '</u>';
+  if (
+    text.startsWith(open) &&
+    text.endsWith(close) &&
+    text.length >= open.length + close.length
+  ) {
+    const inner = text.slice(open.length, text.length - close.length);
+    return {
+      changes: { from: range.from, to: range.to, insert: inner },
+      range: EditorSelection.range(range.from, range.from + inner.length),
+    };
+  }
+  const innerLen = text.length;
+  return {
+    changes: { from: range.from, to: range.to, insert: open + text + close },
+    range: EditorSelection.range(
+      range.from + open.length,
+      range.from + open.length + innerLen,
+    ),
+  };
+}
+
+const toggleHtmlUnderline: Command = (view) => {
+  const { state } = view;
+  const specs: { range: SelectionRange; changes: ChangeSpec }[] = [];
+  for (const range of state.selection.ranges) {
+    if (!isMarkdownContext(state, range.from)) return false;
+    const spec = toggleUnderlineMarkup(state, range);
+    if (!spec) return false;
+    specs.push(spec);
+  }
+  let i = 0;
+  view.dispatch({
+    ...state.changeByRange(() => specs[i++] as { range: SelectionRange; changes: ChangeSpec }),
+    scrollIntoView: true,
+    userEvent: 'input',
+  });
+  return true;
+};
+
+const insertLink: Command = (view) => {
+  const { state } = view;
+  for (const range of state.selection.ranges) {
+    if (range.empty || !isMarkdownContext(state, range.from)) return false;
+  }
+  const url =
+    typeof globalThis.prompt === 'function'
+      ? globalThis.prompt('Link URL', 'https://')
+      : null;
+  if (url == null) return false;
+  view.dispatch({
+    ...state.changeByRange((range) => {
+      const label = state.sliceDoc(range.from, range.to);
+      const insert = `[${label}](${url})`;
+      return {
+        changes: { from: range.from, to: range.to, insert },
+        range: EditorSelection.cursor(range.from + insert.length),
+      };
+    }),
+    scrollIntoView: true,
+    userEvent: 'input',
+  });
+  return true;
+};
+
+/**
+ * Key bindings for common rich-text shortcuts in Markdown (Mod = Ctrl on
+ * Windows/Linux, Cmd on macOS). Placed ahead of CodeMirror defaults so
+ * **Mod-i** and **Mod-u** apply formatting instead of syntax selection /
+ * selection undo.
+ */
+export const prosemarkMarkdownFormattingKeymap: readonly KeyBinding[] = [
+  { key: 'Mod-b', run: toggleStrongEmphasis, preventDefault: true },
+  { key: 'Mod-i', run: toggleEmphasis, preventDefault: true },
+  { key: 'Mod-`', run: toggleInlineCode, preventDefault: true },
+  { key: 'Mod-k', run: insertLink, preventDefault: true },
+  { key: 'Mod-u', run: toggleHtmlUnderline, preventDefault: true },
+  { key: 'Mod-Shift-x', run: toggleStrikethrough, preventDefault: true },
+];
+
+export function prosemarkMarkdownFormattingKeymapExtension(): Extension {
+  return keymap.of([...prosemarkMarkdownFormattingKeymap]);
+}

--- a/packages/core/lib/markdownFormattingKeymap.ts
+++ b/packages/core/lib/markdownFormattingKeymap.ts
@@ -17,6 +17,20 @@ function isMarkdownContext(state: EditorState, pos: number): boolean {
   );
 }
 
+/**
+ * Among syntax nodes that match `predicate` and overlap the range `[from, to]`,
+ * return the one that spans the selection most broadly (smallest `from`, largest
+ * `to`).
+ *
+ * We need the **outermost** match so toggling matches user intent in nested
+ * inline markup (e.g. `***bold italic***`: an inner `StrongEmphasis` sits inside
+ * an outer `Emphasis`). If the selection lies inside both, stripping the
+ * innermost delimiter pair first would leave broken markup; preferring the
+ * widest covering node removes the whole construct the user is effectively
+ * “inside.” Scanning every offset in `[from, to]` covers selections that start
+ * or end between Lezer tokens so we still find a node that fully wraps the
+ * selection.
+ */
 function findOutermostCoveringNode(
   state: EditorState,
   from: number,
@@ -38,6 +52,12 @@ function findOutermostCoveringNode(
   return found;
 }
 
+/**
+ * If the selection is already wrapped by a matching node (e.g. `StrongEmphasis`
+ * for `**…**`), remove that wrapper and leave the inner text selected.
+ * Otherwise wrap the selection with `open`/`close` and select the former
+ * selection bounds inside the new delimiters.
+ */
 function toggleInlineMarkup(
   state: EditorState,
   range: SelectionRange,
@@ -78,6 +98,14 @@ function toggleInlineMarkup(
   };
 }
 
+/**
+ * Builds a `Command` that toggles one kind of inline markup for every selection
+ * range. We precompute each range’s `{ changes, range }` from the **initial**
+ * document, then feed them into `EditorState.changeByRange` in order. That API
+ * merges all edits and remaps selections in one transaction; using a counter
+ * closure ties the *i*-th spec to the *i*-th range without recomputing from a
+ * half-updated document (which would break multiple cursors).
+ */
 function makeToggleInlineCommand(
   nodeName: string,
   open: string,
@@ -107,6 +135,12 @@ const toggleEmphasis = makeToggleInlineCommand('Emphasis', '*', '*');
 const toggleInlineCode = makeToggleInlineCommand('InlineCode', '`', '`');
 const toggleStrikethrough = makeToggleInlineCommand('Strikethrough', '~~', '~~');
 
+/**
+ * Wraps the selection as a Markdown link: selected text becomes the **label**
+ * in `[label]()`. Cursor is placed inside the empty parentheses so the URL can
+ * be typed next. With no selection, inserts `[]()` and focuses the label
+ * brackets first.
+ */
 const insertLink: Command = (view) => {
   const { state } = view;
   for (const range of state.selection.ranges) {
@@ -116,6 +150,8 @@ const insertLink: Command = (view) => {
     ...state.changeByRange((range) => {
       const label = state.sliceDoc(range.from, range.to);
       const insert = range.empty ? `[]()` : `[${label}]()`;
+      // Empty: cursor after `[` to type the label. Non-empty: cursor after `](`
+      // so the URL is typed inside `()`.
       const head = range.empty
         ? range.from + 1
         : range.from + 1 + label.length + 2;

--- a/packages/core/lib/markdownFormattingKeymap.ts
+++ b/packages/core/lib/markdownFormattingKeymap.ts
@@ -131,7 +131,7 @@ function makeToggleInlineCommand(
 }
 
 const toggleStrongEmphasis = makeToggleInlineCommand('StrongEmphasis', '**', '**');
-const toggleEmphasis = makeToggleInlineCommand('Emphasis', '*', '*');
+const toggleEmphasis = makeToggleInlineCommand('Emphasis', '_', '_');
 const toggleInlineCode = makeToggleInlineCommand('InlineCode', '`', '`');
 const toggleStrikethrough = makeToggleInlineCommand('Strikethrough', '~~', '~~');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds Markdown formatting shortcuts to `prosemarkBasicSetup`: Mod-b (bold), Mod-i (italic), Mod-backtick (inline code), Mod-k (wrap as `[label]()` with cursor in the URL), Mod-Shift-x (strikethrough when GFM is enabled). No Mod-u / HTML underline (not supported yet).
- Exports `prosemarkMarkdownFormattingKeymap` and `prosemarkMarkdownFormattingKeymapExtension` for custom setups.
- Inline comments in `markdownFormattingKeymap.ts` document outermost-node lookup, toggle behavior, `changeByRange` batching, and link insertion.
- Adds `.cursor/rules/changesets.mdc` for the Changesets workflow.
- Changeset: `.changeset/markdown-format-keybinds.md`.

## Testing

- `bun run lint`, `bun run check-types`, `bun test`, and `bun run build` in `packages/core`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a97ef91-f7aa-40e6-aaa2-1813cc419b59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a97ef91-f7aa-40e6-aaa2-1813cc419b59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

