### PR TITLE
feat(render-html): block HTML widgets with margin containment

### DIFF
--- a/.changeset/render-html-block-widgets.md
+++ b/.changeset/render-html-block-widgets.md
@@ -1,0 +1,5 @@
+---
+"@prosemark/render-html": patch
+---
+
+Render folded HTML blocks as **block** replace widgets: outer `.cm-html-widget` uses padding (no vertical margin), inner `.cm-html-widget__content` uses `display: flow-root` to contain margins from rendered content. Call `requestMeasure` after DOM updates and on `ResizeObserver` resize. Set `proseMarkSkipAdjacentArrowReveal` on the decoration so arrow movement through blank lines after a block behaves normally (with `revealBlockOnArrowExtension` in core).

--- a/apps/docs/src/content/docs/reference/features.md
+++ b/apps/docs/src/content/docs/reference/features.md
@@ -27,6 +27,8 @@ These features are illustrated in our [Demo](/demo).
 
 - HTML Blocks inside markdown can be rendered. HTML content is sanitized using [DOMPurify](https://github.com/cure53/DOMPurify).
 
+- Folded HTML blocks use **block** replace widgets: an outer shell avoids vertical margins (padding only), and an inner `flow-root` wrapper contains margins from rendered elements (for example headings) so CodeMirror’s line layout stays accurate. `requestMeasure` runs after updates and when the widget resizes (`ResizeObserver` where available).
+
 - Inline HTML is not supported yet.
 
 ## `@prosemark/paste-rich-text`

--- a/packages/render-html/lib/main.ts
+++ b/packages/render-html/lib/main.ts
@@ -13,6 +13,11 @@ export {
   renderHtmlMarkdownSyntaxExtensions,
 } from './markdown';
 
+const WIDGET_ROOT_CLASS = 'cm-html-widget';
+const WIDGET_CONTENT_CLASS = 'cm-html-widget__content';
+
+const htmlWidgetResizeObservers = new WeakMap<HTMLElement, ResizeObserver>();
+
 class HTMLWidget extends WidgetType {
   constructor(public value: string) {
     super();
@@ -22,52 +27,77 @@ class HTMLWidget extends WidgetType {
     return this.value === other.value;
   }
 
-  toDOM() {
-    const el = document.createElement('div');
-    el.className = 'cm-html-widget';
+  toDOM(view: EditorView): HTMLElement {
+    const root = document.createElement('div');
+    root.className = WIDGET_ROOT_CLASS;
+
+    const inner = document.createElement('div');
+    inner.className = WIDGET_CONTENT_CLASS;
+
     const parsed = new DOMParser().parseFromString(
       DOMPurify.sanitize(this.value),
       'text/html',
     );
 
-    const walk = (root: Node) => {
-      for (const node of [...root.childNodes]) {
-        if (node.nodeType === 3) {
-          // this node is a text node
-          if (/^\s*$/.test(node.nodeValue ?? '')) {
-            node.remove();
+    const walk = (n: Node) => {
+      for (const child of [...n.childNodes]) {
+        if (child.nodeType === 3) {
+          if (/^\s*$/.test(child.nodeValue ?? '')) {
+            child.remove();
             continue;
           }
 
-          node.textContent =
-            node.textContent?.replace(/[\t\n\r ]+/g, ' ').trim() ?? null;
+          child.textContent =
+            child.textContent?.replace(/[\t\n\r ]+/g, ' ').trim() ?? null;
         } else {
-          walk(node);
+          walk(child);
         }
       }
     };
 
     walk(parsed.body);
+    inner.append(...parsed.body.childNodes);
+    root.appendChild(inner);
 
-    el.append(...parsed.body.childNodes);
-    return el;
+    if (typeof ResizeObserver !== 'undefined') {
+      const ro = new ResizeObserver(() => {
+        view.requestMeasure();
+      });
+      ro.observe(root);
+      htmlWidgetResizeObservers.set(root, ro);
+    }
+
+    requestAnimationFrame(() => {
+      view.requestMeasure();
+    });
+
+    return root;
   }
 
-  // allows clicks to pass through to the editor
-  ignoreEvent(_event: Event) {
+  ignoreEvent(_event: Event): boolean {
     return false;
-    // return event.type !== 'mousedown'; // don't preventDefault for mousedown
   }
 
   destroy(dom: HTMLElement): void {
+    htmlWidgetResizeObservers.get(dom)?.disconnect();
+    htmlWidgetResizeObservers.delete(dom);
     dom.remove();
   }
 }
 
 const htmlBlockTheme = EditorView.theme({
-  '.cm-html-widget': {
-    padding: '0 2px 0 6px;',
+  [`.${WIDGET_ROOT_CLASS}`]: {
+    // Block replace widgets: no vertical margin on the root (CodeMirror layout).
+    display: 'flow-root',
+    boxSizing: 'border-box',
+    padding: '0 2px 0 6px',
     borderRadius: '0.5rem',
+  },
+  [`.${WIDGET_CONTENT_CLASS}`]: {
+    // Contain margins from rendered HTML (headings, lists, etc.) so they do not
+    // collapse outside the widget box and confuse line-height measurement.
+    display: 'flow-root',
+    minHeight: '1px',
   },
 });
 
@@ -77,11 +107,12 @@ export const htmlBlockExtension = [
     buildDecorations: (state: EditorState, node: SyntaxNodeRef) => {
       return Decoration.replace({
         widget: new HTMLWidget(state.doc.sliceString(node.from, node.to)),
-        block: false,
+        block: true,
         inclusive: true,
+        proseMarkSkipAdjacentArrowReveal: true,
       }).range(node.from, node.to);
     },
   }),
   htmlBlockTheme,
-  selectAllDecorationsOnSelectExtension('cm-html-widget'),
+  selectAllDecorationsOnSelectExtension(WIDGET_ROOT_CLASS),
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**`@prosemark/render-html`** — folded HTML blocks are now **block** replace widgets with correct CodeMirror layout:

- Outer **`.cm-html-widget`**: `flow-root`, horizontal padding + radius only (no vertical margin per CodeMirror block-widget guidance).
- Inner **`.cm-html-widget__content`**: `flow-root` + `min-height: 1px` so margins from rendered HTML (e.g. headings) stay inside the measured box.
- **`requestMeasure`** after build and on **`ResizeObserver`** (when available).
- **`proseMarkSkipAdjacentArrowReveal: true`** so arrow movement through blank lines after a block stays normal with core’s `revealBlockOnArrowExtension`.

## Docs

- **`apps/docs/src/content/docs/reference/features.md`** — short note under `@prosemark/render-html`.

## Changeset

- **`.changeset/render-html-block-widgets.md`** — `@prosemark/render-html` patch only.

*(LaTeX, core math markdown, MathJax bundling, and `revealBlockOnArrow` fixes landed in #120 / `main`; this PR is rebased on `main` and contains only render-html + docs.)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8de082c-1e3a-4758-958a-44c6a18e61d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8de082c-1e3a-4758-958a-44c6a18e61d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

