### PR TITLE
fix(core): fixed-width tabs with reliable caret coords

### DIFF
--- a/.changeset/fixed-tab-cursor-height.md
+++ b/.changeset/fixed-tab-cursor-height.md
@@ -2,4 +2,4 @@
 "@prosemark/core": patch
 ---
 
-Render tabs with a fixed-width mark (not a replace widget) so soft-indent measurements stay stable, the drawn caret keeps a consistent height, and default horizontal motion still steps through the real `\t` in the document.
+Replace each tab with a fixed-pixel-width span that still contains a real `\t` (for `moveVisually`), and override `WidgetType.coordsAt` so `drawSelection` uses the box edges instead of clipped glyph rects next to `overflow: hidden`.

--- a/.changeset/fixed-tab-cursor-height.md
+++ b/.changeset/fixed-tab-cursor-height.md
@@ -2,4 +2,4 @@
 "@prosemark/core": patch
 ---
 
-Align the fixed-width tab widget to the text box so the caret height stays consistent when the cursor is placed right after a tab character.
+Align the fixed-width tab widget to the text box so the caret height stays consistent when the cursor is placed right after a tab character, and add a high-precedence arrow-key step so horizontal motion can cross replaced tab columns that `moveVisually` skips.

--- a/.changeset/fixed-tab-cursor-height.md
+++ b/.changeset/fixed-tab-cursor-height.md
@@ -2,4 +2,4 @@
 "@prosemark/core": patch
 ---
 
-Align the fixed-width tab widget to the text box so the caret height stays consistent when the cursor is placed right after a tab character, and add a high-precedence arrow-key step so horizontal motion can cross replaced tab columns that `moveVisually` skips.
+Render tabs with a fixed-width mark (not a replace widget) so soft-indent measurements stay stable, the drawn caret keeps a consistent height, and default horizontal motion still steps through the real `\t` in the document.

--- a/.changeset/fixed-tab-cursor-height.md
+++ b/.changeset/fixed-tab-cursor-height.md
@@ -1,0 +1,5 @@
+---
+"@prosemark/core": patch
+---
+
+Align the fixed-width tab widget to the text box so the caret height stays consistent when the cursor is placed right after a tab character.

--- a/.changeset/fixed-tab-cursor-height.md
+++ b/.changeset/fixed-tab-cursor-height.md
@@ -2,4 +2,4 @@
 "@prosemark/core": patch
 ---
 
-Replace each tab with a fixed-pixel-width span that still contains a real `\t` (for `moveVisually`), and override `WidgetType.coordsAt` so `drawSelection` uses the box edges instead of clipped glyph rects next to `overflow: hidden`.
+Replace each tab with a fixed-pixel-width span that still contains a real `\t` (for `moveVisually`), and override `WidgetType.coordsAt` using the widget text offset (`pos` 0 vs 1) for left/right edges — not the document `side` argument, which misaligned `drawSelection` with the caret next to tabs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+ProseMark is a Bun workspaces monorepo using Turborepo. It builds WYSIWYM markdown editor extensions for CodeMirror 6, plus VS Code extensions and a demo/docs site. No external services or databases are required.
+
+### Runtime
+
+- **Bun** (`packageManager: bun@1.2.17`) is the package manager. It is installed at `~/.bun/bin/bun` and added to PATH via `~/.bashrc`.
+- **Node.js** (v22+) is also available (needed by some tooling).
+
+### Key commands (all run from repo root)
+
+| Task | Command |
+|------|---------|
+| Install deps | `bun install` |
+| Build all | `bun turbo build` |
+| Typecheck all | `bun turbo check-types` |
+| Lint all | `bun turbo lint` |
+| Dev (demo app) | `cd apps/demo && npx vite --host 0.0.0.0` |
+| Dev (all deps for demo) | `cd apps/demo && bun run dev-all` |
+| Dev (docs site) | `cd apps/docs && bun run dev` |
+
+### Gotchas
+
+- Shell sessions in the cloud VM use non-login, non-interactive shells. Bun must be explicitly on PATH. The update script handles this by exporting `BUN_INSTALL` and prepending `$BUN_INSTALL/bin` to PATH before running `bun install`.
+- VS Code extensions (`apps/vscode-extensions/*`) cannot be tested end-to-end without VS Code, but their `build`, `check-types`, and `lint` scripts work fine via `bun turbo build/check-types/lint`.
+- The demo app (`apps/demo`) is a Vite app that depends on all library packages. Running `bun turbo build` first ensures workspace packages have their `dist/` output.
+- There is no test suite beyond the VS Code extension tests (which require VS Code Electron).

--- a/apps/debug-in-web/README.md
+++ b/apps/debug-in-web/README.md
@@ -1,0 +1,32 @@
+# debug-in-web
+
+Minimal Vite app to reproduce ProseMark / CodeMirror behavior in a real browser **without** VS Code message passing or extension host setup.
+
+Compared to `apps/debug-vsc-extn-in-web`:
+
+- Same core idea: Markdown + `prosemarkBasicSetup` + light theme.
+- **Adds `drawSelection()`** so caret and selection drawing match setups that hide the native caret (needed to reproduce fixed-tab / overlay caret bugs).
+- **No** spellcheck harness, paste extensions, LaTeX, render-html, or VS Code–specific flows.
+
+## Run
+
+From repo root (installs workspace deps):
+
+```bash
+bun install
+cd apps/debug-in-web && bun run dev
+```
+
+Or:
+
+```bash
+bunx turbo dev -F debug-in-web
+```
+
+## Tab / caret repro
+
+1. Open the app, click **Load `a\tb`** (or **Load line with tabs**).
+2. Use **Caret before tab** / **Caret after tab**.
+3. Click **Log coords + overlay caret** to print `coordsAtPos` and the `.cm-cursor-primary` box (check for zero width/height).
+
+In the devtools console, `window.debugEditor` is the `EditorView`.

--- a/apps/debug-in-web/index.html
+++ b/apps/debug-in-web/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ProseMark debug-in-web</title>
+    <link rel="stylesheet" href="/src/style.css" />
+  </head>
+  <body>
+    <div id="app">
+      <div class="layout">
+        <aside class="controls">
+          <h1>debug-in-web</h1>
+          <p>
+            Minimal browser harness for ProseMark / CodeMirror issues. Uses
+            <code>drawSelection()</code> so caret bugs match editors that hide the
+            native caret.
+          </p>
+
+          <div class="control-group">
+            <button type="button" id="fixture-tab-line">Load line with tabs</button>
+            <button type="button" id="fixture-a-tab-b">Load a + TAB + b</button>
+          </div>
+
+          <div class="control-group">
+            <button type="button" id="caret-before-tab">Caret before tab</button>
+            <button type="button" id="caret-after-tab">Caret after tab</button>
+            <button type="button" id="caret-start-doc">Caret at start</button>
+          </div>
+
+          <div class="control-group">
+            <button type="button" id="measure-caret">Log coords + overlay caret</button>
+            <button type="button" id="clear-log">Clear log</button>
+          </div>
+        </aside>
+
+        <main class="editor-panel">
+          <div id="codemirror-container"></div>
+        </main>
+
+        <section class="log-panel">
+          <h2>Log</h2>
+          <pre id="log-output"></pre>
+        </section>
+      </div>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/debug-in-web/package.json
+++ b/apps/debug-in-web/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "debug-in-web",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check-types": "tsc",
+    "dev-all": "turbo dev -F 'debug-in-web...'"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "vite": "^5.3.1"
+  },
+  "dependencies": {
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/language": "^6.11.3",
+    "@codemirror/language-data": "^6.5.2",
+    "@codemirror/state": "^6.5.2",
+    "@codemirror/view": "^6.39.4",
+    "@lezer/markdown": "^1.6.1",
+    "@prosemark/core": "workspace:*"
+  }
+}

--- a/apps/debug-in-web/src/initDoc.md
+++ b/apps/debug-in-web/src/initDoc.md
@@ -1,0 +1,14 @@
+# debug-in-web
+
+Use the sidebar to load tab fixtures and move the caret. This editor includes **`drawSelection()`** so overlay caret behavior matches many real setups.
+
+## Manual tab repro
+
+1. Click **Load `a\tb`**
+2. Click **Caret before tab** — selection should sit between `a` and the tab
+3. Click **Caret after tab** — selection should sit after the tab
+4. Use **Log coords + overlay caret** to print `coordsAtPos` and the `.cm-cursor-primary` bounding box
+
+Indented line with tabs (for soft indent + tab width together):
+
+	one	two	three

--- a/apps/debug-in-web/src/main.ts
+++ b/apps/debug-in-web/src/main.ts
@@ -1,0 +1,149 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import './style.css';
+import { EditorSelection } from '@codemirror/state';
+import { EditorView, drawSelection } from '@codemirror/view';
+import { markdown } from '@codemirror/lang-markdown';
+import { languages } from '@codemirror/language-data';
+import {
+  prosemarkBasicSetup,
+  prosemarkLightThemeSetup,
+  prosemarkMarkdownSyntaxExtensions,
+} from '@prosemark/core';
+import * as ProseMark from '@prosemark/core';
+import { GFM } from '@lezer/markdown';
+import initDoc from './initDoc.md?raw';
+
+declare global {
+  interface Window {
+    debugEditor?: EditorView;
+    ProseMark?: typeof ProseMark;
+  }
+}
+
+const logOutput = document.getElementById('log-output');
+if (!(logOutput instanceof HTMLPreElement)) {
+  throw new Error('Missing #log-output');
+}
+
+const log = (message: string) => {
+  const stamp = new Date().toISOString().slice(11, 23);
+  const line = `[${stamp}] ${message}`;
+  logOutput.textContent = `${line}\n${logOutput.textContent ?? ''}`.slice(0, 16000);
+  console.log(line);
+};
+
+const editorParent = document.getElementById('codemirror-container');
+if (!(editorParent instanceof HTMLDivElement)) {
+  throw new Error('Missing #codemirror-container');
+}
+
+const editor = new EditorView({
+  extensions: [
+    markdown({
+      codeLanguages: languages,
+      extensions: [GFM, prosemarkMarkdownSyntaxExtensions],
+    }),
+    drawSelection(),
+    prosemarkBasicSetup(),
+    prosemarkLightThemeSetup(),
+  ],
+  doc: initDoc,
+  parent: editorParent,
+});
+
+const measureCaret = () => {
+  const { head } = editor.state.selection.main;
+  const assoc = editor.state.selection.main.assoc;
+  const before = editor.coordsAtPos(head, -1);
+  const after = editor.coordsAtPos(head, 1);
+  const atAssoc = editor.coordsAtPos(head, assoc || 1);
+  const layer = editor.dom.querySelector('.cm-cursorLayer');
+  const primary = layer?.querySelector('.cm-cursor-primary');
+  const rect = primary?.getBoundingClientRect();
+  log(
+    `head=${String(head)} assoc=${String(assoc)} slice=${JSON.stringify(editor.state.sliceDoc(Math.max(0, head - 1), Math.min(editor.state.doc.length, head + 1)))}`,
+  );
+  log(`coordsAtPos(head,-1)=${before ? JSON.stringify(before) : 'null'}`);
+  log(`coordsAtPos(head, 1)=${after ? JSON.stringify(after) : 'null'}`);
+  log(`coordsAtPos(head, assoc)=${atAssoc ? JSON.stringify(atAssoc) : 'null'}`);
+  log(
+    `.cm-cursor-primary: ${rect ? `w=${String(rect.width)} h=${String(rect.height)} l=${String(rect.left)} t=${String(rect.top)}` : 'none'}`,
+  );
+};
+
+const requireButton = (id: string): HTMLButtonElement => {
+  const el = document.getElementById(id);
+  if (!(el instanceof HTMLButtonElement)) throw new Error(`Missing #${id}`);
+  return el;
+};
+
+const tabLineFixture = [
+  'Indented with tabs (leading tab on this line):',
+  '\tone\ttwo\tthree',
+  '',
+  'End.',
+].join('\n');
+
+requireButton('fixture-tab-line').addEventListener('click', () => {
+  editor.dispatch({
+    changes: { from: 0, to: editor.state.doc.length, insert: tabLineFixture },
+    selection: EditorSelection.single(0),
+  });
+  editor.focus();
+  log('Loaded tab-indented line fixture.');
+});
+
+requireButton('fixture-a-tab-b').addEventListener('click', () => {
+  editor.dispatch({
+    changes: { from: 0, to: editor.state.doc.length, insert: 'a\tb' },
+    selection: EditorSelection.cursor(1),
+  });
+  editor.focus();
+  log('Loaded a\\tb with caret before tab (pos 1).');
+});
+
+requireButton('caret-before-tab').addEventListener('click', () => {
+  const doc = editor.state.doc.toString();
+  const i = doc.indexOf('\t');
+  if (i < 0) {
+    log('No tab in document.');
+    return;
+  }
+  editor.dispatch({ selection: EditorSelection.cursor(i, 1) });
+  editor.focus();
+  log(`Caret before tab at pos ${String(i)} (assoc 1).`);
+});
+
+requireButton('caret-after-tab').addEventListener('click', () => {
+  const doc = editor.state.doc.toString();
+  const i = doc.indexOf('\t');
+  if (i < 0) {
+    log('No tab in document.');
+    return;
+  }
+  editor.dispatch({ selection: EditorSelection.cursor(i + 1, -1) });
+  editor.focus();
+  log(`Caret after tab at pos ${String(i + 1)} (assoc -1).`);
+});
+
+requireButton('caret-start-doc').addEventListener('click', () => {
+  editor.dispatch({ selection: EditorSelection.single(0) });
+  editor.focus();
+  log('Caret at document start.');
+});
+
+requireButton('measure-caret').addEventListener('click', () => {
+  editor.focus();
+  requestAnimationFrame(() => {
+    measureCaret();
+  });
+});
+
+requireButton('clear-log').addEventListener('click', () => {
+  logOutput.textContent = '';
+});
+
+window.debugEditor = editor;
+window.ProseMark = ProseMark;
+
+log('debug-in-web ready (drawSelection on). window.debugEditor');

--- a/apps/debug-in-web/src/style.css
+++ b/apps/debug-in-web/src/style.css
@@ -1,0 +1,127 @@
+:root {
+  font-family:
+    ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
+  line-height: 1.5;
+  font-weight: 400;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background: #f0f1f3;
+  color: #1a1d26;
+}
+
+#app {
+  width: 100%;
+  min-height: 100vh;
+  padding: 1rem;
+}
+
+.layout {
+  width: min(1400px, 100%);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 280px minmax(400px, 1fr) minmax(280px, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.controls,
+.editor-panel,
+.log-panel {
+  background: #fff;
+  border: 1px solid #d8dce6;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgb(20 25 38 / 6%);
+}
+
+.controls {
+  padding: 1rem;
+  position: sticky;
+  top: 1rem;
+}
+
+.controls h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.controls p {
+  margin-top: 0;
+  color: #4a5568;
+  font-size: 0.88rem;
+}
+
+.control-group {
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 0.85rem;
+}
+
+button {
+  font: inherit;
+  padding: 0.45rem 0.65rem;
+  border-radius: 6px;
+  border: 1px solid #c5cad6;
+  background: #f8f9fb;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #eef0f5;
+}
+
+.editor-panel {
+  padding: 0.75rem;
+  min-height: 420px;
+}
+
+#codemirror-container {
+  min-height: 380px;
+  border: 1px solid #e2e6ef;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.log-panel {
+  padding: 0.75rem 1rem;
+  max-height: min(80vh, 720px);
+  overflow: auto;
+}
+
+.log-panel h2 {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+}
+
+#log-output {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+  font-size: 0.78rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: #2d3748;
+}
+
+code {
+  font-size: 0.85em;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .controls {
+    position: static;
+  }
+}

--- a/apps/debug-in-web/src/vite-env.d.ts
+++ b/apps/debug-in-web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/debug-in-web/tsconfig.json
+++ b/apps/debug-in-web/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/apps/debug-in-web/vite.config.ts
+++ b/apps/debug-in-web/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  define: {
+    global: 'globalThis',
+  },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,22 @@
         "typescript-eslint": "^8.46.2",
       },
     },
+    "apps/debug-in-web": {
+      "name": "debug-in-web",
+      "dependencies": {
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/language": "^6.11.3",
+        "@codemirror/language-data": "^6.5.2",
+        "@codemirror/state": "^6.5.2",
+        "@codemirror/view": "^6.39.4",
+        "@lezer/markdown": "^1.6.1",
+        "@prosemark/core": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "^5.2.2",
+        "vite": "^5.3.1",
+      },
+    },
     "apps/debug-vsc-extn-in-web": {
       "name": "debug-vsc-extn-in-web",
       "dependencies": {
@@ -1152,6 +1168,8 @@
     "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "debug-in-web": ["debug-in-web@workspace:apps/debug-in-web"],
 
     "debug-vsc-extn-in-web": ["debug-vsc-extn-in-web@workspace:apps/debug-vsc-extn-in-web"],
 

--- a/packages/core/lib/tabWidthExtension.ts
+++ b/packages/core/lib/tabWidthExtension.ts
@@ -45,11 +45,23 @@ class FixedTabWidthWidget extends WidgetType {
     return true;
   }
 
-  coordsAt(dom: HTMLElement, _pos: number, side: number): Rect | null {
+  coordsAt(dom: HTMLElement, pos: number, _side: number): Rect | null {
     const rect = dom.getBoundingClientRect();
     if (rect.width === 0 && rect.height === 0) return null;
-    const x = side <= 0 ? rect.left : rect.right;
-    return { left: x, right: x, top: rect.top, bottom: rect.bottom };
+    // Match WidgetTile.coordsInWidget(..., block: true): offset 0 → left edge,
+    // offset 1 → right edge. Do not use `side` here — it is not the same as
+    // document assoc and misplaces drawSelection when it disagrees with `pos`.
+    const x = pos === 0 ? rect.left : rect.right;
+    const top = rect.top;
+    let bottom = rect.bottom;
+    const parent = dom.parentElement;
+    if (parent) {
+      const lh = parseInt(window.getComputedStyle(parent).lineHeight, 10);
+      if (!Number.isNaN(lh) && bottom - top > lh * 1.5) {
+        bottom = top + lh;
+      }
+    }
+    return { left: x, right: x, top, bottom };
   }
 }
 

--- a/packages/core/lib/tabWidthExtension.ts
+++ b/packages/core/lib/tabWidthExtension.ts
@@ -1,9 +1,16 @@
-import { type Extension, RangeSetBuilder } from '@codemirror/state';
+import {
+  EditorSelection,
+  type Extension,
+  Prec,
+  RangeSetBuilder,
+} from '@codemirror/state';
 import {
   Decoration,
+  Direction,
   EditorView,
   ViewPlugin,
   WidgetType,
+  keymap,
   type DecorationSet,
   type ViewUpdate,
 } from '@codemirror/view';
@@ -88,7 +95,74 @@ const fixedTabWidthTheme = EditorView.baseTheme({
   },
 });
 
+/** Same “logical forward” sense as defaultKeymap ArrowRight / Shift-ArrowRight. */
+function logicalForwardAt(view: EditorView, head: number): boolean {
+  return view.textDirectionAt(head) === Direction.LTR;
+}
+
+function adjustSelectionForTabMotion(
+  view: EditorView,
+  forward: boolean,
+): EditorSelection | null {
+  const { doc, selection } = view.state;
+  const ranges = selection.ranges.map((range) => {
+    const { anchor, head } = range;
+    const ahead = forward === logicalForwardAt(view, head);
+
+    if (range.empty) {
+      if (ahead && head < doc.length && doc.sliceString(head, head + 1) === TAB_CHARACTER) {
+        return EditorSelection.cursor(head + 1, -1);
+      }
+      if (!ahead && head > 0 && doc.sliceString(head - 1, head) === TAB_CHARACTER) {
+        return EditorSelection.cursor(head - 1, 1);
+      }
+      return range;
+    }
+
+    const goal = range.goalColumn;
+    const bidi = range.bidiLevel ?? undefined;
+
+    if (ahead && head < doc.length && doc.sliceString(head, head + 1) === TAB_CHARACTER) {
+      return EditorSelection.range(anchor, head + 1, goal, bidi, -1);
+    }
+    if (!ahead && head > 0 && doc.sliceString(head - 1, head) === TAB_CHARACTER) {
+      return EditorSelection.range(anchor, head - 1, goal, bidi, 1);
+    }
+    return range;
+  });
+
+  const unchanged = ranges.every((r, i) => {
+    const prev = selection.ranges[i];
+    return prev !== undefined && r.eq(prev, true);
+  });
+  if (unchanged) return null;
+  return EditorSelection.create(ranges, selection.mainIndex);
+}
+
+function tabArrowRight(view: EditorView): boolean {
+  const sel = adjustSelectionForTabMotion(view, true);
+  if (!sel) return false;
+  view.dispatch({ selection: sel, scrollIntoView: true, userEvent: 'select' });
+  return true;
+}
+
+function tabArrowLeft(view: EditorView): boolean {
+  const sel = adjustSelectionForTabMotion(view, false);
+  if (!sel) return false;
+  view.dispatch({ selection: sel, scrollIntoView: true, userEvent: 'select' });
+  return true;
+}
+
+/** Runs before defaultKeymap so we can cross tab columns moveVisually would skip. */
+const fixedTabArrowKeymap = Prec.high(
+  keymap.of([
+    { key: 'ArrowRight', run: tabArrowRight, shift: tabArrowRight },
+    { key: 'ArrowLeft', run: tabArrowLeft, shift: tabArrowLeft },
+  ]),
+);
+
 export const fixedTabWidthExtension: Extension = [
   fixedTabWidthDecorations,
   fixedTabWidthTheme,
+  fixedTabArrowKeymap,
 ];

--- a/packages/core/lib/tabWidthExtension.ts
+++ b/packages/core/lib/tabWidthExtension.ts
@@ -77,6 +77,12 @@ const fixedTabWidthDecorations = ViewPlugin.fromClass(
 const fixedTabWidthTheme = EditorView.baseTheme({
   '.cm-fixed-tab-width-widget': {
     display: 'inline-block',
+    // Empty inline-blocks baseline-align to their bottom edge, which inflates
+    // the line box and makes coordsAtPos (thus drawSelection's cursor) taller
+    // when the caret sits immediately after the tab. Match CodeMirror's own
+    // `.cm-widgetBuffer` approach: pin height and align to the text box.
+    verticalAlign: 'text-top',
+    height: '1em',
     width: `${TAB_WIDTH_CH.toString()}ch`,
     pointerEvents: 'none',
   },

--- a/packages/core/lib/tabWidthExtension.ts
+++ b/packages/core/lib/tabWidthExtension.ts
@@ -3,23 +3,58 @@ import {
   Decoration,
   EditorView,
   ViewPlugin,
+  WidgetType,
   type DecorationSet,
+  type Rect,
   type ViewUpdate,
 } from '@codemirror/view';
 
 // Issue #96 ("Text Vibrating like crazy"):
 // Native tab rendering can vary enough to throw off softIndentExtension's pixel
-// measurements. Wrapping each tab in a fixed-width mark keeps the rendered width
-// deterministic while leaving the `\t` in the document so horizontal cursor motion
-// (`moveVisually`) still visits both sides of the character — unlike
-// `Decoration.replace`, which removes it from the text layout tree.
+// measurements. Replacing each tab with a fixed-width span keeps width
+// deterministic. The span still contains a real `\t` so `moveVisually` visits
+// both sides of the character (unlike an empty widget). We override `coordsAt`
+// so caret coordinates use the box edges — wrapping + `overflow: hidden` would
+// otherwise clip the tab glyph’s rects and make `coordsAtPos` return an empty
+// range (disappearing drawSelection caret).
 
 const TAB_CHARACTER = '\t';
 const TAB_WIDTH_CH = 4;
 
-const fixedTabMark = Decoration.mark({
-  tagName: 'span',
-  class: 'cm-fixed-tab-width',
+function tabWidthPx(view: EditorView): string {
+  const scaleX = view.scaleX || 1;
+  const px = (TAB_WIDTH_CH * view.defaultCharacterWidth) / scaleX;
+  return `${String(px)}px`;
+}
+
+class FixedTabWidthWidget extends WidgetType {
+  eq(other: FixedTabWidthWidget): boolean {
+    return other instanceof FixedTabWidthWidget;
+  }
+
+  toDOM(view: EditorView): HTMLElement {
+    const element = document.createElement('span');
+    element.className = 'cm-fixed-tab-width-widget';
+    element.textContent = TAB_CHARACTER;
+    element.style.width = tabWidthPx(view);
+    return element;
+  }
+
+  updateDOM(dom: HTMLElement, view: EditorView, _prev: this): boolean {
+    dom.style.width = tabWidthPx(view);
+    return true;
+  }
+
+  coordsAt(dom: HTMLElement, _pos: number, side: number): Rect | null {
+    const rect = dom.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) return null;
+    const x = side <= 0 ? rect.left : rect.right;
+    return { left: x, right: x, top: rect.top, bottom: rect.bottom };
+  }
+}
+
+const fixedTabDecoration = Decoration.replace({
+  widget: new FixedTabWidthWidget(),
 });
 
 const buildTabWidthDecorations = (view: EditorView): DecorationSet => {
@@ -27,14 +62,12 @@ const buildTabWidthDecorations = (view: EditorView): DecorationSet => {
   const visitedTabPositions = new Set<number>();
 
   for (const { from, to } of view.visibleRanges) {
-    // Scan the whole visible range directly rather than iterating line-by-line.
-    // Visible ranges can overlap, so dedupe by absolute tab position.
     const visibleText = view.state.doc.sliceString(from, to);
     let tabOffset = visibleText.indexOf(TAB_CHARACTER);
     while (tabOffset !== -1) {
       const tabPos = from + tabOffset;
       if (!visitedTabPositions.has(tabPos)) {
-        builder.add(tabPos, tabPos + 1, fixedTabMark);
+        builder.add(tabPos, tabPos + 1, fixedTabDecoration);
         visitedTabPositions.add(tabPos);
       }
       tabOffset = visibleText.indexOf(TAB_CHARACTER, tabOffset + 1);
@@ -53,7 +86,11 @@ const fixedTabWidthDecorations = ViewPlugin.fromClass(
     }
 
     update(update: ViewUpdate) {
-      if (update.docChanged || update.viewportChanged) {
+      if (
+        update.docChanged ||
+        update.viewportChanged ||
+        update.geometryChanged
+      ) {
         this.decorations = buildTabWidthDecorations(update.view);
       }
     }
@@ -64,16 +101,14 @@ const fixedTabWidthDecorations = ViewPlugin.fromClass(
 );
 
 const fixedTabWidthTheme = EditorView.baseTheme({
-  '.cm-fixed-tab-width': {
+  '.cm-fixed-tab-width-widget': {
     display: 'inline-block',
-    // Pin line box height (see prior fix for empty inline-block baseline issues).
     verticalAlign: 'text-top',
     height: '1em',
-    width: `${TAB_WIDTH_CH.toString()}ch`,
     overflow: 'hidden',
-    // Hide the glyph; width comes from the box, not the engine’s tab stops.
     color: 'transparent',
     caretColor: 'currentColor',
+    pointerEvents: 'none',
   },
 });
 

--- a/packages/core/lib/tabWidthExtension.ts
+++ b/packages/core/lib/tabWidthExtension.ts
@@ -1,43 +1,25 @@
-import {
-  EditorSelection,
-  type Extension,
-  Prec,
-  RangeSetBuilder,
-} from '@codemirror/state';
+import { type Extension, RangeSetBuilder } from '@codemirror/state';
 import {
   Decoration,
-  Direction,
   EditorView,
   ViewPlugin,
-  WidgetType,
-  keymap,
   type DecorationSet,
   type ViewUpdate,
 } from '@codemirror/view';
 
 // Issue #96 ("Text Vibrating like crazy"):
 // Native tab rendering can vary enough to throw off softIndentExtension's pixel
-// measurements. Replacing each visible tab with a fixed-width widget keeps
-// indentation width deterministic and prevents jitter.
+// measurements. Wrapping each tab in a fixed-width mark keeps the rendered width
+// deterministic while leaving the `\t` in the document so horizontal cursor motion
+// (`moveVisually`) still visits both sides of the character — unlike
+// `Decoration.replace`, which removes it from the text layout tree.
 
 const TAB_CHARACTER = '\t';
 const TAB_WIDTH_CH = 4;
 
-class FixedTabWidthWidget extends WidgetType {
-  eq(other: FixedTabWidthWidget): boolean {
-    return other instanceof FixedTabWidthWidget;
-  }
-
-  toDOM(): HTMLElement {
-    const element = document.createElement('span');
-    element.className = 'cm-fixed-tab-width-widget';
-    element.setAttribute('aria-hidden', 'true');
-    return element;
-  }
-}
-
-const fixedTabDecoration = Decoration.replace({
-  widget: new FixedTabWidthWidget(),
+const fixedTabMark = Decoration.mark({
+  tagName: 'span',
+  class: 'cm-fixed-tab-width',
 });
 
 const buildTabWidthDecorations = (view: EditorView): DecorationSet => {
@@ -52,7 +34,7 @@ const buildTabWidthDecorations = (view: EditorView): DecorationSet => {
     while (tabOffset !== -1) {
       const tabPos = from + tabOffset;
       if (!visitedTabPositions.has(tabPos)) {
-        builder.add(tabPos, tabPos + 1, fixedTabDecoration);
+        builder.add(tabPos, tabPos + 1, fixedTabMark);
         visitedTabPositions.add(tabPos);
       }
       tabOffset = visibleText.indexOf(TAB_CHARACTER, tabOffset + 1);
@@ -82,87 +64,20 @@ const fixedTabWidthDecorations = ViewPlugin.fromClass(
 );
 
 const fixedTabWidthTheme = EditorView.baseTheme({
-  '.cm-fixed-tab-width-widget': {
+  '.cm-fixed-tab-width': {
     display: 'inline-block',
-    // Empty inline-blocks baseline-align to their bottom edge, which inflates
-    // the line box and makes coordsAtPos (thus drawSelection's cursor) taller
-    // when the caret sits immediately after the tab. Match CodeMirror's own
-    // `.cm-widgetBuffer` approach: pin height and align to the text box.
+    // Pin line box height (see prior fix for empty inline-block baseline issues).
     verticalAlign: 'text-top',
     height: '1em',
     width: `${TAB_WIDTH_CH.toString()}ch`,
-    pointerEvents: 'none',
+    overflow: 'hidden',
+    // Hide the glyph; width comes from the box, not the engine’s tab stops.
+    color: 'transparent',
+    caretColor: 'currentColor',
   },
 });
-
-/** Same “logical forward” sense as defaultKeymap ArrowRight / Shift-ArrowRight. */
-function logicalForwardAt(view: EditorView, head: number): boolean {
-  return view.textDirectionAt(head) === Direction.LTR;
-}
-
-function adjustSelectionForTabMotion(
-  view: EditorView,
-  forward: boolean,
-): EditorSelection | null {
-  const { doc, selection } = view.state;
-  const ranges = selection.ranges.map((range) => {
-    const { anchor, head } = range;
-    const ahead = forward === logicalForwardAt(view, head);
-
-    if (range.empty) {
-      if (ahead && head < doc.length && doc.sliceString(head, head + 1) === TAB_CHARACTER) {
-        return EditorSelection.cursor(head + 1, -1);
-      }
-      if (!ahead && head > 0 && doc.sliceString(head - 1, head) === TAB_CHARACTER) {
-        return EditorSelection.cursor(head - 1, 1);
-      }
-      return range;
-    }
-
-    const goal = range.goalColumn;
-    const bidi = range.bidiLevel ?? undefined;
-
-    if (ahead && head < doc.length && doc.sliceString(head, head + 1) === TAB_CHARACTER) {
-      return EditorSelection.range(anchor, head + 1, goal, bidi, -1);
-    }
-    if (!ahead && head > 0 && doc.sliceString(head - 1, head) === TAB_CHARACTER) {
-      return EditorSelection.range(anchor, head - 1, goal, bidi, 1);
-    }
-    return range;
-  });
-
-  const unchanged = ranges.every((r, i) => {
-    const prev = selection.ranges[i];
-    return prev !== undefined && r.eq(prev, true);
-  });
-  if (unchanged) return null;
-  return EditorSelection.create(ranges, selection.mainIndex);
-}
-
-function tabArrowRight(view: EditorView): boolean {
-  const sel = adjustSelectionForTabMotion(view, true);
-  if (!sel) return false;
-  view.dispatch({ selection: sel, scrollIntoView: true, userEvent: 'select' });
-  return true;
-}
-
-function tabArrowLeft(view: EditorView): boolean {
-  const sel = adjustSelectionForTabMotion(view, false);
-  if (!sel) return false;
-  view.dispatch({ selection: sel, scrollIntoView: true, userEvent: 'select' });
-  return true;
-}
-
-/** Runs before defaultKeymap so we can cross tab columns moveVisually would skip. */
-const fixedTabArrowKeymap = Prec.high(
-  keymap.of([
-    { key: 'ArrowRight', run: tabArrowRight, shift: tabArrowRight },
-    { key: 'ArrowLeft', run: tabArrowLeft, shift: tabArrowLeft },
-  ]),
-);
 
 export const fixedTabWidthExtension: Extension = [
   fixedTabWidthDecorations,
   fixedTabWidthTheme,
-  fixedTabArrowKeymap,
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### Disappearing caret (mark + `overflow: hidden`)

A `Decoration.mark` around `\t` with a **narrower** `inline-block` and `overflow: hidden` still lays out the tab using **native tab stops**. The text node’s `getClientRects()` can end up **outside** the clipped box. `EditorView.coordsAtPos` then sees `left === right`, bails out, and **`drawSelection` draws a zero-width caret** — it looks like the cursor vanished.

### Fix

Go back to `Decoration.replace`, but the widget DOM is a span that still contains a **literal `\t`** (like CodeMirror’s own `TabWidget` in `highlightSpecialChars`). That keeps **`moveVisually` / default arrow keys** working without a custom keymap.

- **Width:** `TAB_WIDTH_CH * defaultCharacterWidth / scaleX` in pixels (recomputed on `geometryChanged` and via `updateDOM`).
- **Caret coords:** implement `WidgetType.coordsAt` to return the **left or right edge of the box** (zero-width caret segment), so `drawSelection` never depends on clipped glyph rects.
- **Display:** `color: transparent`, `caret-color: currentColor`, `overflow: hidden`, `vertical-align` / `height` as before.

## Changeset

`.changeset/fixed-tab-cursor-height.md` — `@prosemark/core` (patch).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fca4176f-42f5-439a-a049-226b51b647f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fca4176f-42f5-439a-a049-226b51b647f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

