### PR TITLE
fix(docs): correct LaTeX math layout on demo page

### DIFF
--- a/apps/docs/src/components/ProseMarkDemo.astro
+++ b/apps/docs/src/components/ProseMarkDemo.astro
@@ -2,8 +2,10 @@
 
 ---
 
-<div id="app">
-  <div id="codemirror-container"></div>
+<div class="not-content prosemark-demo-root">
+  <div id="app">
+    <div id="codemirror-container"></div>
+  </div>
 </div>
 
 <script>
@@ -160,15 +162,12 @@
     padding: 2rem;
   }
 
-  #codemirror-container {
+  .prosemark-demo-root #codemirror-container {
     min-height: 100px;
     width: 100%;
     /* Inter + tailwindcss font-sans*/
     --font:
       Inter, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
       'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-    * {
-      margin-top: 0px;
-    }
   }
 </style>

--- a/apps/docs/src/content/docs/reference/styling.md
+++ b/apps/docs/src/content/docs/reference/styling.md
@@ -160,9 +160,6 @@ Example base typography plus all variables used on [prosemark.com](/):
   min-height: 100px;
   width: 100%;
   --font: Inter;
-  * {
-    margin-top: 0px;
-  }
 }
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Starlight’s markdown prose styles apply `display: block`, `max-width: 100%`, and `height: auto` to **all** `svg` elements inside `.sl-markdown-content` (see `@astrojs/starlight/style/markdown.css`). MathJax SVG output inherits those rules, which breaks inline/display math layout on the docs demo compared to the standalone Vite demo.

## Changes

- Wrap the embedded ProseMark demo in Starlight’s **`not-content`** class so editor widgets (including MathJax `svg`) are excluded from prose image/svg rules.
- Remove the `#codemirror-container * { margin-top: 0 }` reset from `ProseMarkDemo.astro` and from the matching snippet in **Reference → Styling**, so behavior matches `apps/demo` (block images keep normal vertical rhythm).

## Testing

- `bun run build` in `apps/docs` currently fails in this workspace due to existing TypeDoc errors in `@prosemark/latex` / `@prosemark/core` exports (unrelated to this CSS-only change).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a62cb5e-4065-4bd0-93cb-09711646741d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a62cb5e-4065-4bd0-93cb-09711646741d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

