### PR TITLE
fix: whitespace around logo attribution

### DIFF
--- a/apps/debug-vsc-extn-in-web/index.html
+++ b/apps/debug-vsc-extn-in-web/index.html
@@ -16,14 +16,18 @@
           </p>
 
           <div class="control-group">
-            <button id="load-code-fence-fixture">Load Code Fence Fixture</button>
+            <button id="load-code-fence-fixture">
+              Load Code Fence Fixture
+            </button>
             <button id="select-code-fence-body">Select First Fence Body</button>
             <button id="stress-selection">Run Selection Stress Loop</button>
           </div>
 
           <div class="control-group">
             <button id="run-spellcheck-now">Run Spellcheck Now</button>
-            <button id="simulate-outdated-spellcheck">Simulate Outdated Spellcheck Apply</button>
+            <button id="simulate-outdated-spellcheck">
+              Simulate Outdated Spellcheck Apply
+            </button>
             <button id="clear-spellcheck">Clear Spellcheck Issues</button>
           </div>
 
@@ -38,7 +42,13 @@
             </label>
             <label>
               Spellcheck delay (ms)
-              <input id="spellcheck-delay-ms" type="number" min="0" step="10" value="120" />
+              <input
+                id="spellcheck-delay-ms"
+                type="number"
+                min="0"
+                step="10"
+                value="120"
+              />
             </label>
           </div>
 

--- a/apps/debug-vsc-extn-in-web/scripts/repro-codefence.mjs
+++ b/apps/debug-vsc-extn-in-web/scripts/repro-codefence.mjs
@@ -54,7 +54,8 @@ const server = http.createServer(async (req, res) => {
     const body = await fs.readFile(filePath);
     res.setHeader(
       'Content-Type',
-      contentTypeByExt.get(path.extname(filePath)) ?? 'application/octet-stream',
+      contentTypeByExt.get(path.extname(filePath)) ??
+        'application/octet-stream',
     );
     res.end(body);
   } catch (error) {

--- a/apps/debug-vsc-extn-in-web/src/main.ts
+++ b/apps/debug-vsc-extn-in-web/src/main.ts
@@ -41,7 +41,10 @@ if (!(logOutput instanceof HTMLPreElement)) {
 const log = (message: string) => {
   const stamp = new Date().toISOString().slice(11, 23);
   const line = `[${stamp}] ${message}`;
-  logOutput.textContent = `${line}\n${logOutput.textContent ?? ''}`.slice(0, 12000);
+  logOutput.textContent = `${line}\n${logOutput.textContent ?? ''}`.slice(
+    0,
+    12000,
+  );
   console.log(line);
 };
 
@@ -224,7 +227,9 @@ requireButton('clear-log').addEventListener('click', () => {
 window.addEventListener('error', (event) => {
   log(
     `window.error: ${event.message || 'Unknown error'}${
-      event.error instanceof Error ? ` :: ${event.error.stack ?? event.error.message}` : ''
+      event.error instanceof Error
+        ? ` :: ${event.error.stack ?? event.error.message}`
+        : ''
     }`,
   );
 });
@@ -232,7 +237,9 @@ window.addEventListener('error', (event) => {
 window.addEventListener('unhandledrejection', (event) => {
   log(
     `unhandledrejection: ${
-      event.reason instanceof Error ? event.reason.stack ?? event.reason.message : String(event.reason)
+      event.reason instanceof Error
+        ? (event.reason.stack ?? event.reason.message)
+        : String(event.reason)
     }`,
   );
 });

--- a/apps/debug-vsc-extn-in-web/src/spellcheck.ts
+++ b/apps/debug-vsc-extn-in-web/src/spellcheck.ts
@@ -40,7 +40,9 @@ const sleep = (ms: number) =>
   });
 
 const buildIssueRanges = (text: string) => {
-  const misspellings = extractWords(text).filter((w) => !nspell.correct(w.word));
+  const misspellings = extractWords(text).filter(
+    (w) => !nspell.correct(w.word),
+  );
   return misspellings.map(({ word, from, to }) =>
     new SpellcheckIssue(
       word,
@@ -91,7 +93,9 @@ export const createSpellcheckHarness = (
 
     if (staleResultGuardEnabled) {
       if (requestId !== latestRequestId) {
-        log(`Dropped stale spellcheck result (request ${requestId.toString()}).`);
+        log(
+          `Dropped stale spellcheck result (request ${requestId.toString()}).`,
+        );
         return;
       }
       if (view.state.doc.toString() !== sourceText) {
@@ -136,7 +140,9 @@ export const createSpellcheckHarness = (
     runSpellcheck,
     clearIssues: (view) => {
       view.dispatch({
-        effects: issueCompartment.reconfigure([spellcheckIssues.of(RangeSet.of([]))]),
+        effects: issueCompartment.reconfigure([
+          spellcheckIssues.of(RangeSet.of([])),
+        ]),
       });
       log('Cleared spellcheck issues.');
     },

--- a/apps/debug-vsc-extn-in-web/src/style.css
+++ b/apps/debug-vsc-extn-in-web/src/style.css
@@ -1,168 +1,169 @@
 :root {
-  font-family:
-    Inter, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  line-height: 1.5;
-  font-weight: 400;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+    font-family:
+        Inter, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+        'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+    line-height: 1.5;
+    font-weight: 400;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 * {
-  box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 body {
-  margin: 0;
-  min-width: 320px;
-  min-height: 100vh;
-  background: #f7f7f8;
-  color: #16181d;
+    margin: 0;
+    min-width: 320px;
+    min-height: 100vh;
+    background: #f7f7f8;
+    color: #16181d;
 }
 
 #app {
-  width: 100%;
-  min-height: 100vh;
-  padding: 1rem;
+    width: 100%;
+    min-height: 100vh;
+    padding: 1rem;
 }
 
 .layout {
-  width: min(1600px, 100%);
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: 320px minmax(480px, 1fr) 360px;
-  gap: 1rem;
-  align-items: start;
+    width: min(1600px, 100%);
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 320px minmax(480px, 1fr) 360px;
+    gap: 1rem;
+    align-items: start;
 }
 
 .controls,
 .editor-panel,
 .log-panel {
-  background: #ffffff;
-  border: 1px solid #dde1e8;
-  border-radius: 10px;
-  box-shadow: 0 3px 10px rgb(20 25 38 / 4%);
+    background: #ffffff;
+    border: 1px solid #dde1e8;
+    border-radius: 10px;
+    box-shadow: 0 3px 10px rgb(20 25 38 / 4%);
 }
 
 .controls {
-  padding: 1rem;
-  position: sticky;
-  top: 1rem;
+    padding: 1rem;
+    position: sticky;
+    top: 1rem;
 }
 
 .controls h1 {
-  margin: 0 0 0.5rem;
-  font-size: 1.15rem;
+    margin: 0 0 0.5rem;
+    font-size: 1.15rem;
 }
 
 .controls p {
-  margin-top: 0;
-  color: #4a5568;
-  font-size: 0.92rem;
+    margin-top: 0;
+    color: #4a5568;
+    font-size: 0.92rem;
 }
 
 .control-group {
-  display: grid;
-  gap: 0.5rem;
-  margin-bottom: 0.9rem;
+    display: grid;
+    gap: 0.5rem;
+    margin-bottom: 0.9rem;
 }
 
 .control-group.toggles {
-  border: 1px solid #ebedf2;
-  border-radius: 8px;
-  padding: 0.65rem;
+    border: 1px solid #ebedf2;
+    border-radius: 8px;
+    padding: 0.65rem;
 }
 
 label {
-  display: grid;
-  gap: 0.25rem;
-  font-size: 0.9rem;
-  color: #2b3340;
+    display: grid;
+    gap: 0.25rem;
+    font-size: 0.9rem;
+    color: #2b3340;
 }
 
 input[type='number'] {
-  width: 100%;
-  border: 1px solid #ced3dd;
-  border-radius: 6px;
-  padding: 0.3rem 0.45rem;
-  font: inherit;
+    width: 100%;
+    border: 1px solid #ced3dd;
+    border-radius: 6px;
+    padding: 0.3rem 0.45rem;
+    font: inherit;
 }
 
 button {
-  border: 1px solid #c4ccda;
-  border-radius: 8px;
-  background: #f5f7fc;
-  padding: 0.45rem 0.55rem;
-  text-align: left;
-  font: inherit;
-  cursor: pointer;
+    border: 1px solid #c4ccda;
+    border-radius: 8px;
+    background: #f5f7fc;
+    padding: 0.45rem 0.55rem;
+    text-align: left;
+    font: inherit;
+    cursor: pointer;
 }
 
 button:hover {
-  background: #e9eefc;
+    background: #e9eefc;
 }
 
 .editor-panel {
-  min-height: 86vh;
-  padding: 0.35rem 0.6rem;
+    min-height: 86vh;
+    padding: 0.35rem 0.6rem;
 }
 
 #codemirror-container {
-  min-height: 82vh;
-  width: 100%;
-  display: flex;
-  cursor: text;
-  --font:
-    Inter, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --pm-blockquote-vertical-line-background-color: gray;
+    min-height: 82vh;
+    width: 100%;
+    display: flex;
+    cursor: text;
+    --font:
+        Inter, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+        'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+    --pm-blockquote-vertical-line-background-color: gray;
 }
 
 #codemirror-container > .cm-editor {
-  flex: 1;
+    flex: 1;
 }
 
 #codemirror-container > .cm-editor,
 #codemirror-container > .cm-editor > .cm-scroller,
 #codemirror-container > .cm-editor > .cm-scroller > .cm-content {
-  min-height: 100%;
+    min-height: 100%;
 }
 
 .log-panel {
-  padding: 1rem;
-  position: sticky;
-  top: 1rem;
+    padding: 1rem;
+    position: sticky;
+    top: 1rem;
 }
 
 .log-panel h2 {
-  margin-top: 0;
-  margin-bottom: 0.55rem;
-  font-size: 1rem;
+    margin-top: 0;
+    margin-bottom: 0.55rem;
+    font-size: 1rem;
 }
 
 #log-output {
-  margin: 0;
-  max-height: 82vh;
-  overflow: auto;
-  white-space: pre-wrap;
-  word-break: break-word;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 0.78rem;
-  background: #111827;
-  color: #d7e3fd;
-  border-radius: 8px;
-  padding: 0.7rem;
+    margin: 0;
+    max-height: 82vh;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family:
+        ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.78rem;
+    background: #111827;
+    color: #d7e3fd;
+    border-radius: 8px;
+    padding: 0.7rem;
 }
 
 @media (max-width: 1400px) {
-  .layout {
-    grid-template-columns: 300px minmax(380px, 1fr);
-  }
+    .layout {
+        grid-template-columns: 300px minmax(380px, 1fr);
+    }
 
-  .log-panel {
-    grid-column: 1 / -1;
-    position: static;
-  }
+    .log-panel {
+        grid-column: 1 / -1;
+        position: static;
+    }
 }

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -40,9 +40,9 @@ Static assets, like favicons, can be placed in the `public/` directory.
 
 All commands are run from the root of the project, from a terminal:
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `bun install`             | Installs dependencies                            |
+| Command               | Action                                           |
+| :-------------------- | :----------------------------------------------- |
+| `bun install`         | Installs dependencies                            |
 | `bun dev`             | Starts local dev server at `localhost:4321`      |
 | `bun build`           | Build your production site to `./dist/`          |
 | `bun preview`         | Preview your build locally, before deploying     |

--- a/apps/docs/src/components/LogoAttrib.astro
+++ b/apps/docs/src/components/LogoAttrib.astro
@@ -7,9 +7,6 @@
   <a
     href="https://thenounproject.com/browse/icons/term/quill/"
     target="_blank"
-    title="quill Icons"
-  >
-    Noun Project
-  </a>{' '}
-  (CC BY 3.0)
+    title="quill Icons">Noun Project</a
+  >{' '}(CC BY 3.0)
 </div>

--- a/apps/docs/src/components/ProseMarkDemo.astro
+++ b/apps/docs/src/components/ProseMarkDemo.astro
@@ -89,8 +89,8 @@
     --pm-muted-color: oklch(37.2% 0.044 257.287);
     --pm-code-background-color: oklch(92.9% 0.013 255.508);
     --pm-code-font:
-      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-      'Liberation Mono', 'Courier New', monospace;
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+      'Courier New', monospace;
     --pm-code-btn-background-color: oklch(86.9% 0.022 252.894);
     --pm-code-btn-hover-background-color: oklch(70.4% 0.04 256.788);
     --pm-blockquote-vertical-line-background-color: oklch(70.4% 0.04 256.788);
@@ -126,8 +126,8 @@
     --pm-muted-color: oklch(55.4% 0.046 257.417);
     --pm-code-background-color: oklch(27.9% 0.041 260.031);
     --pm-code-font:
-      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-      'Liberation Mono', 'Courier New', monospace;
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+      'Courier New', monospace;
     --pm-code-btn-background-color: oklch(37.2% 0.044 257.287);
     --pm-code-btn-hover-background-color: oklch(44.6% 0.043 257.281);
     --pm-blockquote-vertical-line-background-color: oklch(44.6% 0.043 257.281);

--- a/apps/docs/src/content.config.ts
+++ b/apps/docs/src/content.config.ts
@@ -3,5 +3,5 @@ import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
-	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
 };

--- a/apps/docs/src/content/docs/reference/styling.md
+++ b/apps/docs/src/content/docs/reference/styling.md
@@ -11,38 +11,38 @@ Used by `prosemarkBaseThemeSetup()` / `prosemarkLightThemeSetup()` and related t
 
 ### Prose and editor controls
 
-| Variable | Purpose |
-| -------- | ------- |
-| `--pm-header-mark-color` | ATX (`#`) and Setext (`=====` / `-----`) heading markers |
-| `--pm-link-color` | Links |
-| `--pm-muted-color` | Muted / secondary text |
-| `--pm-code-background-color` | Inline code and code-fence background |
-| `--pm-code-font` | Monospace stack for inline code and fenced blocks |
-| `--pm-code-btn-background-color` | Code-fence toolbar button background |
-| `--pm-code-btn-hover-background-color` | Code-fence toolbar button hover |
-| `--pm-blockquote-vertical-line-background-color` | Block quote bar |
-| `--pm-cursor-color` | Caret |
+| Variable                                         | Purpose                                                  |
+| ------------------------------------------------ | -------------------------------------------------------- |
+| `--pm-header-mark-color`                         | ATX (`#`) and Setext (`=====` / `-----`) heading markers |
+| `--pm-link-color`                                | Links                                                    |
+| `--pm-muted-color`                               | Muted / secondary text                                   |
+| `--pm-code-background-color`                     | Inline code and code-fence background                    |
+| `--pm-code-font`                                 | Monospace stack for inline code and fenced blocks        |
+| `--pm-code-btn-background-color`                 | Code-fence toolbar button background                     |
+| `--pm-code-btn-hover-background-color`           | Code-fence toolbar button hover                          |
+| `--pm-blockquote-vertical-line-background-color` | Block quote bar                                          |
+| `--pm-cursor-color`                              | Caret                                                    |
 
 ### Syntax highlighting (code fences)
 
 These follow CodeMirror tag names mapped in the ProseMark theme:
 
-| Variable | Typical use |
-| -------- | ----------- |
-| `--pm-syntax-link` | Links in code |
-| `--pm-syntax-keyword` | Keywords |
-| `--pm-syntax-atom` | Atoms |
-| `--pm-syntax-literal` | Literals |
-| `--pm-syntax-string` | Strings |
-| `--pm-syntax-regexp` | Regex |
-| `--pm-syntax-definition-variable` | Definitions |
-| `--pm-syntax-local-variable` | Locals |
-| `--pm-syntax-type-namespace` | Types / namespaces |
-| `--pm-syntax-class-name` | Class names |
-| `--pm-syntax-special-variable-macro` | Specials / macros |
-| `--pm-syntax-definition-property` | Properties |
-| `--pm-syntax-comment` | Comments |
-| `--pm-syntax-invalid` | Invalid / error |
+| Variable                             | Typical use        |
+| ------------------------------------ | ------------------ |
+| `--pm-syntax-link`                   | Links in code      |
+| `--pm-syntax-keyword`                | Keywords           |
+| `--pm-syntax-atom`                   | Atoms              |
+| `--pm-syntax-literal`                | Literals           |
+| `--pm-syntax-string`                 | Strings            |
+| `--pm-syntax-regexp`                 | Regex              |
+| `--pm-syntax-definition-variable`    | Definitions        |
+| `--pm-syntax-local-variable`         | Locals             |
+| `--pm-syntax-type-namespace`         | Types / namespaces |
+| `--pm-syntax-class-name`             | Class names        |
+| `--pm-syntax-special-variable-macro` | Specials / macros  |
+| `--pm-syntax-definition-property`    | Properties         |
+| `--pm-syntax-comment`                | Comments           |
+| `--pm-syntax-invalid`                | Invalid / error    |
 
 `@prosemark/render-html` and `@prosemark/paste-rich-text` do not define their own `--pm-*` variables; they inherit the same editor surface and code styling from core.
 
@@ -50,22 +50,22 @@ These follow CodeMirror tag names mapped in the ProseMark theme:
 
 ### Underlines
 
-| Variable | Purpose |
-| -------- | ------- |
-| `--pm-spellcheck-issue-underline-color` | Wavy underline on misspelled ranges |
+| Variable                                 | Purpose                                      |
+| ---------------------------------------- | -------------------------------------------- |
+| `--pm-spellcheck-issue-underline-color`  | Wavy underline on misspelled ranges          |
 | `--pm-spellcheck-issue-background-color` | Background on marked text (often left unset) |
 
 ### Tooltip
 
-| Variable | Purpose |
-| -------- | ------- |
-| `--pm-spellcheck-tooltip-background` | Tooltip panel background |
-| `--pm-spellcheck-tooltip-border` | Tooltip border |
-| `--pm-spellcheck-tooltip-text` | Primary text and headings |
-| `--pm-spellcheck-tooltip-error` | Error state text |
-| `--pm-spellcheck-tooltip-hover` | Row hover for suggestions and actions |
+| Variable                                 | Purpose                                   |
+| ---------------------------------------- | ----------------------------------------- |
+| `--pm-spellcheck-tooltip-background`     | Tooltip panel background                  |
+| `--pm-spellcheck-tooltip-border`         | Tooltip border                            |
+| `--pm-spellcheck-tooltip-text`           | Primary text and headings                 |
+| `--pm-spellcheck-tooltip-error`          | Error state text                          |
+| `--pm-spellcheck-tooltip-hover`          | Row hover for suggestions and actions     |
 | `--pm-spellcheck-tooltip-actions-border` | Separator between actions and suggestions |
-| `--pm-spellcheck-tooltip-font-size` | Tooltip font size |
+| `--pm-spellcheck-tooltip-font-size`      | Tooltip font size                         |
 
 In VS Code, `--pm-spellcheck-issue-underline-color` is set from the editor theme in the ProseMark webview; see the extension stylesheet in the repo to align with that behavior.
 
@@ -89,8 +89,8 @@ Example base typography plus all variables used on [prosemark.com](/):
   --pm-muted-color: oklch(37.2% 0.044 257.287);
   --pm-code-background-color: oklch(92.9% 0.013 255.508);
   --pm-code-font:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    'Liberation Mono', 'Courier New', monospace;
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
   --pm-code-btn-background-color: oklch(86.9% 0.022 252.894);
   --pm-code-btn-hover-background-color: oklch(70.4% 0.04 256.788);
   --pm-blockquote-vertical-line-background-color: oklch(70.4% 0.04 256.788);
@@ -126,8 +126,8 @@ Example base typography plus all variables used on [prosemark.com](/):
   --pm-muted-color: oklch(55.4% 0.046 257.417);
   --pm-code-background-color: oklch(27.9% 0.041 260.031);
   --pm-code-font:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    'Liberation Mono', 'Courier New', monospace;
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
   --pm-code-btn-background-color: oklch(37.2% 0.044 257.287);
   --pm-code-btn-hover-background-color: oklch(44.6% 0.043 257.281);
   --pm-blockquote-vertical-line-background-color: oklch(44.6% 0.043 257.281);

--- a/apps/vscode-extensions/core/.vscode-test.mjs
+++ b/apps/vscode-extensions/core/.vscode-test.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
-	files: 'out/test/**/*.test.js',
+  files: 'out/test/**/*.test.js',
 });

--- a/apps/vscode-extensions/core/src/sub-extensions/core.ts
+++ b/apps/vscode-extensions/core/src/sub-extensions/core.ts
@@ -40,11 +40,21 @@ export class Core implements SubExtension<
   }
 
   getWebviewScriptUri(): vscode.Uri {
-    return vscode.Uri.joinPath(this.#extensionUri, 'dist', 'webview', 'webview.js');
+    return vscode.Uri.joinPath(
+      this.#extensionUri,
+      'dist',
+      'webview',
+      'webview.js',
+    );
   }
 
   getWebviewStyleUri(): vscode.Uri {
-    return vscode.Uri.joinPath(this.#extensionUri, 'dist', 'webview', 'vscode-prosemark.css');
+    return vscode.Uri.joinPath(
+      this.#extensionUri,
+      'dist',
+      'webview',
+      'vscode-prosemark.css',
+    );
   }
 
   getLocalResourceRoots(): vscode.Uri[] {

--- a/apps/vscode-extensions/core/vite.config.ts
+++ b/apps/vscode-extensions/core/vite.config.ts
@@ -1,18 +1,18 @@
-import { defineConfig } from "vite";
-import { resolve } from "node:path";
+import { defineConfig } from 'vite';
+import { resolve } from 'node:path';
 
 export default defineConfig({
   build: {
-    outDir: "dist/webview",
-    target: "es2020",
+    outDir: 'dist/webview',
+    target: 'es2020',
     lib: {
-      entry: resolve(__dirname, "src/webview/main.ts"),
-      name: "webview",
-      formats: ["iife"],
-      fileName: () => "webview.js",
+      entry: resolve(__dirname, 'src/webview/main.ts'),
+      name: 'webview',
+      formats: ['iife'],
+      fileName: () => 'webview.js',
     },
     rollupOptions: {
-      external: ["vscode"],
+      external: ['vscode'],
     },
   },
 });

--- a/apps/vscode-extensions/cspell-integration/.vscode-test.mjs
+++ b/apps/vscode-extensions/cspell-integration/.vscode-test.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
-	files: 'out/test/**/*.test.js',
+  files: 'out/test/**/*.test.js',
 });

--- a/apps/vscode-extensions/cspell-integration/src/sub-extension.ts
+++ b/apps/vscode-extensions/cspell-integration/src/sub-extension.ts
@@ -41,11 +41,21 @@ export class CSpellIntegration implements SubExtension<
   }
 
   getWebviewScriptUri(): vscode.Uri {
-    return vscode.Uri.joinPath(this.#extensionUri, 'dist', 'webview', 'webview.js');
+    return vscode.Uri.joinPath(
+      this.#extensionUri,
+      'dist',
+      'webview',
+      'webview.js',
+    );
   }
 
   getWebviewStyleUri(): vscode.Uri {
-    return vscode.Uri.joinPath(this.#extensionUri, 'dist', 'webview', 'vscode-prosemark-cspell-integration.css');
+    return vscode.Uri.joinPath(
+      this.#extensionUri,
+      'dist',
+      'webview',
+      'vscode-prosemark-cspell-integration.css',
+    );
   }
 
   getLocalResourceRoots(): vscode.Uri[] {

--- a/apps/vscode-extensions/cspell-integration/src/webview/main.ts
+++ b/apps/vscode-extensions/cspell-integration/src/webview/main.ts
@@ -130,7 +130,10 @@ const procs: WebviewProcMap = {
 
     const issueRanges = (issues ?? [])
       .map((is) => {
-        const from = getDocOffset(is.range.start.line, is.range.start.character);
+        const from = getDocOffset(
+          is.range.start.line,
+          is.range.start.character,
+        );
         const to = getDocOffset(is.range.end.line, is.range.end.character);
         if (from === undefined || to === undefined) {
           return undefined;
@@ -153,7 +156,10 @@ const procs: WebviewProcMap = {
           return result;
         });
 
-        return new SpellcheckIssue(is.text, suggestions).range(safeFrom, safeTo);
+        return new SpellcheckIssue(is.text, suggestions).range(
+          safeFrom,
+          safeTo,
+        );
       })
       .filter(isDefined);
 

--- a/apps/vscode-extensions/cspell-integration/vite.config.ts
+++ b/apps/vscode-extensions/cspell-integration/vite.config.ts
@@ -1,20 +1,20 @@
-import { defineConfig } from "vite";
-import { resolve } from "node:path";
-import proseMarkVSCodeExtensionIntegratorPlugin from "@prosemark/vscode-extension-integrator/rolldown-plugin";
+import { defineConfig } from 'vite';
+import { resolve } from 'node:path';
+import proseMarkVSCodeExtensionIntegratorPlugin from '@prosemark/vscode-extension-integrator/rolldown-plugin';
 
 export default defineConfig({
   plugins: [proseMarkVSCodeExtensionIntegratorPlugin()],
   build: {
-    outDir: "dist/webview",
-    target: "es2020",
+    outDir: 'dist/webview',
+    target: 'es2020',
     lib: {
-      entry: resolve(__dirname, "src/webview/main.ts"),
-      name: "webview",
-      formats: ["iife"],
-      fileName: () => "webview.js",
+      entry: resolve(__dirname, 'src/webview/main.ts'),
+      name: 'webview',
+      formats: ['iife'],
+      fileName: () => 'webview.js',
     },
     rollupOptions: {
-      external: ["vscode"],
+      external: ['vscode'],
     },
   },
 });

--- a/apps/vscode-extensions/latex-integration/src/extension.ts
+++ b/apps/vscode-extensions/latex-integration/src/extension.ts
@@ -13,9 +13,7 @@ export function activate(context: vscode.ExtensionContext): void {
   }
   const proseMarkApi = proseMarkExtension.exports;
 
-  const createLatexIntegration_ = createLatexIntegration(
-    context.extensionUri,
-  );
+  const createLatexIntegration_ = createLatexIntegration(context.extensionUri);
   proseMarkApi.registerSubExtension(extId, createLatexIntegration_);
 }
 

--- a/packages/core/lib/codeFenceExtension.ts
+++ b/packages/core/lib/codeFenceExtension.ts
@@ -79,10 +79,7 @@ const codeBlockDecorations = (view: EditorView) => {
                 line.from,
                 line.from,
                 Decoration.widget({
-                  widget: new CodeBlockInfoWidget(
-                    lang,
-                    code,
-                  ),
+                  widget: new CodeBlockInfoWidget(lang, code),
                 }),
               );
             }

--- a/packages/core/lib/fold/dashes.ts
+++ b/packages/core/lib/fold/dashes.ts
@@ -1,61 +1,66 @@
-import type { InlineContext, MarkdownConfig } from "@lezer/markdown";
-import { markdownTags } from "../markdown/tags";
-import { Decoration, WidgetType } from "@codemirror/view";
-import { foldableSyntaxFacet } from "./core";
+import type { InlineContext, MarkdownConfig } from '@lezer/markdown';
+import { markdownTags } from '../markdown/tags';
+import { Decoration, WidgetType } from '@codemirror/view';
+import { foldableSyntaxFacet } from './core';
 
 export const dashMarkdownSyntaxExtension: MarkdownConfig = {
-    defineNodes: [{
-        name: "Dash",
-        style: markdownTags.dash
-    }],
-    parseInline: [{
-        name: "Dash",
-        parse: (cx: InlineContext, next: number, pos: number): number => {
-            if (next !== 45 /* - */ || (pos > 1 && cx.char(pos-1) == 45)) return -1;
-            
-            let i;
-            for (i = pos; i < cx.end && cx.char(i) === 45; i++);
-            if (i - pos > 3) return -1;
+  defineNodes: [
+    {
+      name: 'Dash',
+      style: markdownTags.dash,
+    },
+  ],
+  parseInline: [
+    {
+      name: 'Dash',
+      parse: (cx: InlineContext, next: number, pos: number): number => {
+        if (next !== 45 /* - */ || (pos > 1 && cx.char(pos - 1) == 45))
+          return -1;
 
-            return cx.addElement(cx.elt("Dash", pos, i));
-        },
+        let i;
+        for (i = pos; i < cx.end && cx.char(i) === 45; i++);
+        if (i - pos > 3) return -1;
+
+        return cx.addElement(cx.elt('Dash', pos, i));
+      },
       before: 'Emphasis',
-    }]
-}
+    },
+  ],
+};
 
 class DashWidget extends WidgetType {
-    constructor(public dashCount: number) {
-        super();
-    }
+  constructor(public dashCount: number) {
+    super();
+  }
 
-    eq(other: DashWidget): boolean {
-        return this.dashCount === other.dashCount;
-    }
+  eq(other: DashWidget): boolean {
+    return this.dashCount === other.dashCount;
+  }
 
-    toDOM() {
-        const span = document.createElement("span");
-        span.className = "cm-dash";
-        if (this.dashCount === 2) {
-            span.innerHTML = "&#8211;"; // en dash
-        } else if (this.dashCount === 3) {
-            span.innerHTML = "&#8212;"; // em dash
-        } else {
-            // Not used, just in case something weird happens
-            span.innerHTML = "-".repeat(this.dashCount);
-        }
-        return span;
+  toDOM() {
+    const span = document.createElement('span');
+    span.className = 'cm-dash';
+    if (this.dashCount === 2) {
+      span.innerHTML = '&#8211;'; // en dash
+    } else if (this.dashCount === 3) {
+      span.innerHTML = '&#8212;'; // em dash
+    } else {
+      // Not used, just in case something weird happens
+      span.innerHTML = '-'.repeat(this.dashCount);
     }
+    return span;
+  }
 }
 
 export const dashExtension = foldableSyntaxFacet.of({
-    nodePath: "Dash",
-    buildDecorations: (_state, node) => {
-        const dashCount = node.to - node.from;
-        if (dashCount < 2 || dashCount > 3) {
-            return;
-        }
-        return Decoration.replace({
-            widget: new DashWidget(dashCount)
-        })
-        .range(node.from, node.to);}
+  nodePath: 'Dash',
+  buildDecorations: (_state, node) => {
+    const dashCount = node.to - node.from;
+    if (dashCount < 2 || dashCount > 3) {
+      return;
+    }
+    return Decoration.replace({
+      widget: new DashWidget(dashCount),
+    }).range(node.from, node.to);
+  },
 });

--- a/packages/core/lib/markdown/frontmatter.ts
+++ b/packages/core/lib/markdown/frontmatter.ts
@@ -19,16 +19,18 @@ const isFrontmatterDelimiterLine = (line: Line): boolean => {
   );
 };
 
-const hasClosingDelimiterAhead = (cx: BlockContext, afterPos: number): boolean => {
+const hasClosingDelimiterAhead = (
+  cx: BlockContext,
+  afterPos: number,
+): boolean => {
   const input = (cx as unknown as { input?: Input }).input;
   if (!input) return true;
   const rest = input.read(afterPos, input.length);
   return /(?:^|\n)---[ \t]*(?:\n|$)/.test(rest);
 };
 
-export const isFrontmatterNode = (
-  node: Pick<SyntaxNodeRef, 'name'>,
-): boolean => node.name === 'Frontmatter';
+export const isFrontmatterNode = (node: Pick<SyntaxNodeRef, 'name'>): boolean =>
+  node.name === 'Frontmatter';
 
 const frontmatterYamlMixedParser = parseMixed((node) => {
   if (!isFrontmatterNode(node)) return null;
@@ -49,7 +51,8 @@ export const frontmatterMarkdownSyntaxExtension: MarkdownConfig = {
       name: 'Frontmatter',
       before: 'HorizontalRule',
       parse: (cx: BlockContext, line: Line): boolean => {
-        if (cx.lineStart !== 0 || !isFrontmatterDelimiterLine(line)) return false;
+        if (cx.lineStart !== 0 || !isFrontmatterDelimiterLine(line))
+          return false;
         if (!hasClosingDelimiterAhead(cx, cx.lineStart + line.text.length + 1))
           return false;
 
@@ -84,7 +87,9 @@ export const frontmatterMarkdownSyntaxExtension: MarkdownConfig = {
           );
 
           cx.nextLine();
-          cx.addElement(cx.elt('Frontmatter', from, cx.prevLineEnd(), elements));
+          cx.addElement(
+            cx.elt('Frontmatter', from, cx.prevLineEnd(), elements),
+          );
           return true;
         }
 

--- a/packages/core/lib/markdown/index.ts
+++ b/packages/core/lib/markdown/index.ts
@@ -1,4 +1,7 @@
-import { dashMarkdownSyntaxExtension, emojiMarkdownSyntaxExtension } from '../fold';
+import {
+  dashMarkdownSyntaxExtension,
+  emojiMarkdownSyntaxExtension,
+} from '../fold';
 import { escapeMarkdownSyntaxExtension } from '../hide';
 import { additionalMarkdownSyntaxTags } from '../syntaxHighlighting';
 import { frontmatterMarkdownSyntaxExtension } from './frontmatter';
@@ -14,7 +17,10 @@ export {
 export { nestedLinkAsPlainText } from './nestedLinkAsPlainText';
 export { escapeMarkdownSyntaxExtension } from '../hide';
 export { additionalMarkdownSyntaxTags } from '../syntaxHighlighting';
-export { emojiMarkdownSyntaxExtension, dashMarkdownSyntaxExtension } from '../fold';
+export {
+  emojiMarkdownSyntaxExtension,
+  dashMarkdownSyntaxExtension,
+} from '../fold';
 export {
   mathDelimiterTag,
   mathFormulaTag,

--- a/packages/core/lib/markdown/mathMarkdown.ts
+++ b/packages/core/lib/markdown/mathMarkdown.ts
@@ -59,8 +59,7 @@ export const mathMarkdownSyntaxExtension: MarkdownConfig = {
         if (next !== 36 /* $ */) return -1;
         if (isEscapedDollar(cx, pos)) return -1;
 
-        const display =
-          pos + 1 < cx.end && cx.char(pos + 1) === 36 /* $ */;
+        const display = pos + 1 < cx.end && cx.char(pos + 1) === 36; /* $ */
         const contentFrom = display ? pos + 2 : pos + 1;
         const closePos = display
           ? findClosingDoubleDollar(cx, contentFrom)

--- a/packages/core/lib/markdownFormattingKeymap.ts
+++ b/packages/core/lib/markdownFormattingKeymap.ts
@@ -44,7 +44,8 @@ function findOutermostCoveringNode(
     while (node) {
       if (node.to < from || node.from > to) break;
       if (predicate(node)) {
-        if (!found || node.from < found.from || node.to > found.to) found = node;
+        if (!found || node.from < found.from || node.to > found.to)
+          found = node;
       }
       node = node.parent;
     }
@@ -122,7 +123,9 @@ function makeToggleInlineCommand(
     }
     let i = 0;
     view.dispatch({
-      ...state.changeByRange(() => specs[i++] as { range: SelectionRange; changes: ChangeSpec }),
+      ...state.changeByRange(
+        () => specs[i++] as { range: SelectionRange; changes: ChangeSpec },
+      ),
       scrollIntoView: true,
       userEvent: 'input',
     });
@@ -130,10 +133,18 @@ function makeToggleInlineCommand(
   };
 }
 
-const toggleStrongEmphasis = makeToggleInlineCommand('StrongEmphasis', '**', '**');
+const toggleStrongEmphasis = makeToggleInlineCommand(
+  'StrongEmphasis',
+  '**',
+  '**',
+);
 const toggleEmphasis = makeToggleInlineCommand('Emphasis', '_', '_');
 const toggleInlineCode = makeToggleInlineCommand('InlineCode', '`', '`');
-const toggleStrikethrough = makeToggleInlineCommand('Strikethrough', '~~', '~~');
+const toggleStrikethrough = makeToggleInlineCommand(
+  'Strikethrough',
+  '~~',
+  '~~',
+);
 
 /**
  * Wraps the selection as a Markdown link: selected text becomes the **label**

--- a/packages/core/tests/multiParHTMLBlock.test.ts
+++ b/packages/core/tests/multiParHTMLBlock.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { GFM, parser } from '@lezer/markdown';
 import type { SyntaxNode } from '@lezer/common';
-import {
-  prosemarkMarkdownSyntaxExtensions,
-} from '../lib/markdown/index.ts';
+import { prosemarkMarkdownSyntaxExtensions } from '../lib/markdown/index.ts';
 import {
   multiParHTMLBlockMarkdownSyntaxExtension,
   renderHtmlMarkdownSyntaxExtensions,

--- a/packages/latex/README.md
+++ b/packages/latex/README.md
@@ -20,7 +20,10 @@ Before that import runs, this package sets `window.MathJax = { options: { skipSt
 import { markdown } from '@codemirror/lang-markdown';
 import { GFM } from '@lezer/markdown';
 import { prosemarkMarkdownSyntaxExtensions } from '@prosemark/core';
-import { latexMarkdownSyntaxTheme, latexMarkdownEditorExtensions } from '@prosemark/latex';
+import {
+  latexMarkdownSyntaxTheme,
+  latexMarkdownEditorExtensions,
+} from '@prosemark/latex';
 
 const extensions = [
   markdown({

--- a/packages/latex/lib/main.ts
+++ b/packages/latex/lib/main.ts
@@ -99,10 +99,7 @@ const ensureMathJax = (
     );
   }
 
-  if (
-    configuredPackageUrl !== null &&
-    configuredPackageUrl !== packageUrl
-  ) {
+  if (configuredPackageUrl !== null && configuredPackageUrl !== packageUrl) {
     throw new Error(
       'mathJaxPackageUrl is fixed after the first MathJax load in this page.',
     );
@@ -181,8 +178,11 @@ class RenderLru {
 
 let renderCache: RenderLru | null = null;
 
-const cacheKey = (output: LatexMathOutput, display: boolean, tex: string): string =>
-  `${output}\n${display ? '1' : '0'}\n${tex}`;
+const cacheKey = (
+  output: LatexMathOutput,
+  display: boolean,
+  tex: string,
+): string => `${output}\n${display ? '1' : '0'}\n${tex}`;
 
 const renderOrCloneFromCache = async (
   tex: string,


### PR DESCRIPTION
We should probably run Prettier in CI, it had quite the diff.

Retargeted to main instead of dev as that seems to be where the action is these days.