### PR TITLE
docs: ecosystem section on home page (VS Code extensions)

### DIFF
--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -34,7 +34,7 @@ If you ship something built on ProseMark, we would love to list it here. Open a 
 
 These extensions live under `apps/vscode-extensions/` and are published on the Visual Studio Marketplace:
 
-<CardGrid stagger>
+<CardGrid>
   <LinkCard
     title="ProseMark"
     href="https://marketplace.visualstudio.com/items?itemName=jsimonrichard.vscode-prosemark"

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -30,7 +30,7 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 If you ship something built on ProseMark, we would love to list it here. Open a pull request against [the docs site](https://github.com/jsimonrichard/ProseMark/tree/main/apps/docs) on GitHub.
 
-### VS Code extensions (this repo)
+### Official VS Code Extensions
 
 These extensions live under `apps/vscode-extensions/` and are published on the Visual Studio Marketplace:
 

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -22,5 +22,32 @@ hero:
 ---
 
 import LogoAttrib from '../../components/LogoAttrib.astro';
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 <LogoAttrib />
+
+## Projects using ProseMark
+
+If you ship something built on ProseMark, we would love to list it here. Open a pull request against [the docs site](https://github.com/jsimonrichard/ProseMark/tree/main/apps/docs) on GitHub.
+
+### VS Code extensions (this repo)
+
+These extensions live under `apps/vscode-extensions/` and are published on the Visual Studio Marketplace:
+
+<CardGrid stagger>
+  <LinkCard
+    title="ProseMark"
+    href="https://marketplace.visualstudio.com/items?itemName=jsimonrichard.vscode-prosemark"
+    description='The main ProseMark editor for Markdown ("What You See Is What You Mean").'
+  />
+  <LinkCard
+    title="ProseMark — cSpell integration"
+    href="https://marketplace.visualstudio.com/items?itemName=jsimonrichard.vscode-prosemark-cspell-integration"
+    description="Spell-checking in the ProseMark editor via Code Spell Checker."
+  />
+  <LinkCard
+    title="ProseMark — LaTeX math (MathJax)"
+    href="https://marketplace.visualstudio.com/items?itemName=jsimonrichard.vscode-prosemark-latex-integration"
+    description="Renders $...$ and $$...$$ math in ProseMark using MathJax."
+  />
+</CardGrid>

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -51,3 +51,7 @@ These extensions live under `apps/vscode-extensions/` and are published on the V
     description="Renders $...$ and $$...$$ math in ProseMark using MathJax."
   />
 </CardGrid>
+
+### Desktop Editors
+
+_Coming soon._


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Projects using ProseMark** section to the documentation splash home page (`apps/docs/src/content/docs/index.mdx`). It invites future listings via pull requests and links the official VS Code extensions from `apps/vscode-extensions/` on the Marketplace.

Also adds **Desktop Editors** as a subsection with a *Coming soon.* placeholder.

Uses Starlight `LinkCard` components in a `CardGrid` for the VS Code listings (without `stagger` so the grid height stays compact above **Desktop Editors**).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75f70257-d028-40ca-97d2-caf3fb5eed7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75f70257-d028-40ca-97d2-caf3fb5eed7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Projects using ProseMark" section to the docs site so users can submit PRs to showcase projects.
  * Included curated links to related VS Code extensions (ProseMark editor, cSpell, LaTeX/MathJax) in the docs.
  * Added repository contributor instructions and operational notes for running and testing the workspace.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsimonrichard/ProseMark/pull/134)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->