### PR TITLE
fix(ci): strip workspace devDeps before bun pm pack on publish

### DIFF
--- a/scripts/ci-publish.sh
+++ b/scripts/ci-publish.sh
@@ -18,12 +18,27 @@ else
     PKG_FILE="${SAFE_NAME}-${VERSION}.tgz"
     PKG_PATH="${TMPDIR}/${PKG_FILE}"
 
-    # npm pack (not `bun pm pack`) — Bun fails to resolve private workspace
-    # devDependencies such as @prosemark/eslint-config when creating tarballs.
-    npm pack --pack-destination "${TMPDIR}"
-    if [[ ! -f "${PKG_PATH}" ]]; then
-        echo "Expected pack output at ${PKG_PATH} but file was not created."
-        exit 1
-    fi
+    # `bun pm pack` resolves workspace:* in dependencies (required for publish)
+    # but also tries to resolve devDependencies. Private workspace-only packages
+    # such as @prosemark/eslint-config cannot be resolved for packing; Bun has
+    # no --omit=dev flag for pack, so we strip workspace devDeps temporarily.
+    restore_package_json() {
+        if [[ -n "${PACKAGE_JSON_BACKUP:-}" && -f "${PACKAGE_JSON_BACKUP}" ]]; then
+            mv "${PACKAGE_JSON_BACKUP}" package.json
+        fi
+    }
+    PACKAGE_JSON_BACKUP=$(mktemp)
+    cp package.json "${PACKAGE_JSON_BACKUP}"
+    trap restore_package_json EXIT
+
+    jq '
+      if .devDependencies then
+        .devDependencies |= with_entries(select(.value | test("^workspace:") | not))
+        | if .devDependencies == {} then del(.devDependencies) else . end
+      else .
+      end
+    ' "${PACKAGE_JSON_BACKUP}" >package.json
+
+    bun pm pack --filename "${PKG_PATH}"
     npm publish "${PKG_PATH}"
 fi

--- a/scripts/ci-publish.sh
+++ b/scripts/ci-publish.sh
@@ -18,26 +18,10 @@ else
     PKG_FILE="${SAFE_NAME}-${VERSION}.tgz"
     PKG_PATH="${TMPDIR}/${PKG_FILE}"
 
-    # `bun pm pack` resolves workspace:* in dependencies (required for publish)
-    # but also tries to resolve devDependencies. Private workspace-only packages
-    # such as @prosemark/eslint-config cannot be resolved for packing; Bun has
-    # no --omit=dev flag for pack, so we strip workspace devDeps temporarily.
-    restore_package_json() {
-        if [[ -n "${PACKAGE_JSON_BACKUP:-}" && -f "${PACKAGE_JSON_BACKUP}" ]]; then
-            mv "${PACKAGE_JSON_BACKUP}" package.json
-        fi
-    }
-    PACKAGE_JSON_BACKUP=$(mktemp)
-    cp package.json "${PACKAGE_JSON_BACKUP}"
-    trap restore_package_json EXIT
-
-    jq '
-      if .devDependencies then
-        .devDependencies |= with_entries(select(.value | test("^workspace:") | not))
-        | if .devDependencies == {} then del(.devDependencies) else . end
-      else .
-      end
-    ' "${PACKAGE_JSON_BACKUP}" >package.json
+    # `bun pm pack` resolves workspace:* in dependencies but also tries to
+    # resolve devDependencies (which npm install ignores for consumers anyway).
+    jq 'del(.devDependencies)' package.json >package.json.tmp
+    mv package.json.tmp package.json
 
     bun pm pack --filename "${PKG_PATH}"
     npm publish "${PKG_PATH}"

--- a/scripts/ci-publish.sh
+++ b/scripts/ci-publish.sh
@@ -18,6 +18,12 @@ else
     PKG_FILE="${SAFE_NAME}-${VERSION}.tgz"
     PKG_PATH="${TMPDIR}/${PKG_FILE}"
 
-    bun pm pack --filename $PKG_PATH
-    npm publish $PKG_PATH
+    # npm pack (not `bun pm pack`) — Bun fails to resolve private workspace
+    # devDependencies such as @prosemark/eslint-config when creating tarballs.
+    npm pack --pack-destination "${TMPDIR}"
+    if [[ ! -f "${PKG_PATH}" ]]; then
+        echo "Expected pack output at ${PKG_PATH} but file was not created."
+        exit 1
+    fi
+    npm publish "${PKG_PATH}"
 fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`bun pm pack` fails when resolving private `workspace:*` devDependencies (e.g. `@prosemark/eslint-config`). We need `bun pm pack` so production `workspace:*` dependencies are rewritten to real versions.

## Solution

In CI, delete `devDependencies` from `package.json` before `bun pm pack` (no backup/restore — the checkout is ephemeral). Then pack and `npm publish` as before.

## Why remove all devDependencies?

Published packages should not rely on consumers installing devDependencies; `npm install @prosemark/foo` only installs `dependencies` (and `peerDependencies`). Listing eslint or other dev tools in the published manifest adds no value and can confuse tooling. Stripping the whole field is simpler and matches what actually ships.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62288fea-6dd0-4936-b02a-5fb478f144f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62288fea-6dd0-4936-b02a-5fb478f144f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

