### PR TITLE
chore: changeset for stripping devDependencies on publish

### DIFF
--- a/.changeset/strip-dev-deps-on-publish.md
+++ b/.changeset/strip-dev-deps-on-publish.md
@@ -1,0 +1,10 @@
+---
+'@prosemark/core': patch
+'@prosemark/latex': patch
+'@prosemark/paste-rich-text': patch
+'@prosemark/render-html': patch
+'@prosemark/spellcheck-frontend': patch
+'@prosemark/vscode-extension-integrator': patch
+---
+
+Published packages no longer include `devDependencies` in their npm registry manifest; CI strips `devDependencies` before `bun pm pack` so workspace-only dev tooling is not resolved at publish time.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a changeset to patch all published npm packages so the next release notes document that CI now strips `devDependencies` before `bun pm pack` (merged in #144).

## Packages bumped

- `@prosemark/core`
- `@prosemark/latex`
- `@prosemark/paste-rich-text`
- `@prosemark/render-html`
- `@prosemark/spellcheck-frontend`
- `@prosemark/vscode-extension-integrator`

VS Code extensions are unchanged here; they publish via `vsce` and were not affected by the npm pack change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62288fea-6dd0-4936-b02a-5fb478f144f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62288fea-6dd0-4936-b02a-5fb478f144f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

