### PR TITLE
Fix top-level list soft-indent wrap alignment

### DIFF
--- a/.changeset/fix-top-level-list-soft-indent.md
+++ b/.changeset/fix-top-level-list-soft-indent.md
@@ -1,7 +1,8 @@
 ---
-"@prosemark/core": patch
+'@prosemark/core': patch
 ---
 
 Fix 1–2px soft-indent misalignment on top-level list items when text wraps.
 
-Measure prefix width from the line text-indent origin when the list mark sits at column 0, so the bullet widget's inline offset is included in hanging-indent math.
+Measure prefix width from the line text-indent origin (line box + 6px) instead of
+widget or prefix-character coordinates, so hanging-indent math matches layout.

--- a/.changeset/fix-top-level-list-soft-indent.md
+++ b/.changeset/fix-top-level-list-soft-indent.md
@@ -1,0 +1,7 @@
+---
+"@prosemark/core": patch
+---
+
+Fix 1–2px soft-indent misalignment on top-level list items when text wraps.
+
+Measure prefix width from the line text-indent origin when the list mark sits at column 0, so the bullet widget's inline offset is included in hanging-indent math.

--- a/apps/debug-vsc-extn-in-web/e2e/soft-indent-wrap-alignment.spec.ts
+++ b/apps/debug-vsc-extn-in-web/e2e/soft-indent-wrap-alignment.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test';
+
+const FIXTURE = `- Top level item with enough text to wrap onto a second line easily here is more filler
+  - Nested item with enough text to wrap onto a second line easily here is more filler
+    - Deep nested item with enough text to wrap onto a second line easily here is more filler
+`;
+
+const setDoc = async (page: import('@playwright/test').Page) => {
+  await page.goto('/');
+  await page.waitForSelector('.cm-editor');
+  await page.evaluate((doc) => {
+    const view = window.debugEditor;
+    if (!view) throw new Error('debugEditor missing');
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: doc },
+      selection: { anchor: doc.length },
+    });
+  }, FIXTURE);
+  await page.waitForSelector('.cm-line.cm-soft-indent-line', {
+    timeout: 10_000,
+  });
+};
+
+/** Left edge of the first body character on each visual row of a line. */
+const measureRowsBodyStartLeft = async (
+  line: import('@playwright/test').Locator,
+) =>
+  line.evaluate((el) => {
+    const chars: { left: number; top: number; char: string }[] = [];
+    const walk = (node: Node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const text = node.textContent ?? '';
+        for (let i = 0; i < text.length; i++) {
+          const ch = text[i] ?? '';
+          if (!ch.trim() || ch === '-' || ch === '•') continue;
+          const range = document.createRange();
+          range.setStart(node, i);
+          range.setEnd(node, i + 1);
+          const rect = range.getBoundingClientRect();
+          if (rect.width > 0 || rect.height > 0) {
+            chars.push({ left: rect.left, top: rect.top, char: ch });
+          }
+        }
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        const childEl = node as Element;
+        if (childEl.classList.contains('cm-rendered-list-mark')) return;
+        for (const child of childEl.childNodes) walk(child);
+      }
+    };
+    walk(el);
+
+    const rows = new Map<number, number>();
+    for (const { left, top } of chars) {
+      const roundedTop = Math.round(top);
+      if (!rows.has(roundedTop)) rows.set(roundedTop, left);
+    }
+
+    return [...rows.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([top, left]) => ({ top, left }));
+  });
+
+test.describe('soft indent wrap alignment', () => {
+  test('top-level list items align first row with wrapped rows', async ({
+    page,
+  }) => {
+    await setDoc(page);
+
+    await page.evaluate(() => {
+      const panel = document.querySelector('.editor-panel');
+      if (panel instanceof HTMLElement) panel.style.width = '180px';
+    });
+    await page.waitForTimeout(500);
+
+    const topLine = page
+      .locator('.cm-line.cm-soft-indent-line')
+      .filter({ hasText: 'Top level' })
+      .first();
+    const rows = await measureRowsBodyStartLeft(topLine);
+
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+    const firstRowLeft = rows[0]?.left;
+    const wrappedRowLeft = rows[1]?.left;
+    if (firstRowLeft === undefined || wrappedRowLeft === undefined) {
+      throw new Error('expected wrapped list rows');
+    }
+    expect(Math.abs(firstRowLeft - wrappedRowLeft)).toBeLessThan(1);
+  });
+});

--- a/apps/debug-vsc-extn-in-web/e2e/soft-indent-wrap-alignment.spec.ts
+++ b/apps/debug-vsc-extn-in-web/e2e/soft-indent-wrap-alignment.spec.ts
@@ -61,7 +61,7 @@ const measureRowsBodyStartLeft = async (
   });
 
 test.describe('soft indent wrap alignment', () => {
-  test('top-level list items align first row with wrapped rows', async ({
+  test('list items align first row with wrapped rows at every depth', async ({
     page,
   }) => {
     await setDoc(page);
@@ -72,18 +72,20 @@ test.describe('soft indent wrap alignment', () => {
     });
     await page.waitForTimeout(500);
 
-    const topLine = page
-      .locator('.cm-line.cm-soft-indent-line')
-      .filter({ hasText: 'Top level' })
-      .first();
-    const rows = await measureRowsBodyStartLeft(topLine);
+    for (const label of ['Top level', 'Nested item', 'Deep nested']) {
+      const line = page
+        .locator('.cm-line.cm-soft-indent-line')
+        .filter({ hasText: label })
+        .first();
+      const rows = await measureRowsBodyStartLeft(line);
 
-    expect(rows.length).toBeGreaterThanOrEqual(2);
-    const firstRowLeft = rows[0]?.left;
-    const wrappedRowLeft = rows[1]?.left;
-    if (firstRowLeft === undefined || wrappedRowLeft === undefined) {
-      throw new Error('expected wrapped list rows');
+      expect(rows.length, `${label} should wrap`).toBeGreaterThanOrEqual(2);
+      const firstRowLeft = rows[0]?.left;
+      const wrappedRowLeft = rows[1]?.left;
+      if (firstRowLeft === undefined || wrappedRowLeft === undefined) {
+        throw new Error(`expected wrapped rows for ${label}`);
+      }
+      expect(Math.abs(firstRowLeft - wrappedRowLeft)).toBeLessThan(1);
     }
-    expect(Math.abs(firstRowLeft - wrappedRowLeft)).toBeLessThan(1);
   });
 });

--- a/packages/core/lib/softIndentExtension.ts
+++ b/packages/core/lib/softIndentExtension.ts
@@ -119,15 +119,13 @@ const measurePrefixStartLeft = (
 ): number => {
   const line = view.state.doc.lineAt(bounds.lineFrom);
   const lineEl = lineElementAt(view, line.from);
-  if (lineEl) {
-    return lineEl.getBoundingClientRect().left + SOFT_INDENT_BASE_PADDING;
+  if (!lineEl) {
+    throw new Error(
+      `Soft indent: no .cm-line DOM element for line ${line.number.toString()}`,
+    );
   }
 
-  return (
-    view.coordsAtPos(line.from, 1)?.left ??
-    view.coordsAtPos(bounds.lineFrom, -1)?.left ??
-    0
-  );
+  return lineEl.getBoundingClientRect().left + SOFT_INDENT_BASE_PADDING;
 };
 
 /**

--- a/packages/core/lib/softIndentExtension.ts
+++ b/packages/core/lib/softIndentExtension.ts
@@ -106,29 +106,26 @@ const lineElementAt = (view: EditorView, pos: number): HTMLElement | null => {
   return node.parentElement?.closest('.cm-line') ?? null;
 };
 
-/** Left edge of the hung prefix (before list-mark replace widgets when present). */
+/**
+ * Left edge where the hung prefix begins — the first-row text-indent origin.
+ *
+ * Always uses the line box plus {@link SOFT_INDENT_BASE_PADDING}, matching
+ * `padding-inline-start - text-indent` regardless of replace widgets or leading
+ * whitespace in the markdown prefix.
+ */
 const measurePrefixStartLeft = (
   view: EditorView,
   bounds: SoftIndentPrefixBounds,
 ): number => {
   const line = view.state.doc.lineAt(bounds.lineFrom);
-  // Top-level list/task lines start with a replace widget at column 0. Measuring
-  // from widget coords skips the gap between the text-indent origin (line box +
-  // {@link SOFT_INDENT_BASE_PADDING}) and the bullet, so the first row body sits
-  // ~0.2em right of wrapped rows.
-  const prefixStartsAtLineStart =
-    bounds.lineFrom === line.from && !/^[ \t>]/.test(bounds.prefix);
-
-  if (prefixStartsAtLineStart) {
-    const lineEl = lineElementAt(view, line.from);
-    if (lineEl) {
-      return lineEl.getBoundingClientRect().left + SOFT_INDENT_BASE_PADDING;
-    }
+  const lineEl = lineElementAt(view, line.from);
+  if (lineEl) {
+    return lineEl.getBoundingClientRect().left + SOFT_INDENT_BASE_PADDING;
   }
 
   return (
+    view.coordsAtPos(line.from, 1)?.left ??
     view.coordsAtPos(bounds.lineFrom, -1)?.left ??
-    view.coordsAtPos(bounds.lineFrom, 1)?.left ??
     0
   );
 };

--- a/packages/core/lib/softIndentExtension.ts
+++ b/packages/core/lib/softIndentExtension.ts
@@ -86,6 +86,9 @@ export const matchSoftIndentPrefix = (lineText: string): string | null => {
 const softIndentRefresh = Annotation.define<number>();
 const MAX_REFRESH_ROUNDS = 1;
 
+/** Base inset paired with {@link measureSoftIndentWidth} (blockquote border gutter). */
+const SOFT_INDENT_BASE_PADDING = 6;
+
 interface ChangedLine {
   lineNumber: number;
   lineText: string;
@@ -93,11 +96,42 @@ interface ChangedLine {
   newStyle?: string;
 }
 
+/** DOM `.cm-line` element containing a document position, if mounted. */
+const lineElementAt = (view: EditorView, pos: number): HTMLElement | null => {
+  const domAt = view.domAtPos(pos);
+  const node = domAt.node;
+  if (node instanceof HTMLElement && node.classList.contains('cm-line')) {
+    return node;
+  }
+  return node.parentElement?.closest('.cm-line') ?? null;
+};
+
 /** Left edge of the hung prefix (before list-mark replace widgets when present). */
-const measurePrefixStartLeft = (view: EditorView, lineFrom: number): number =>
-  view.coordsAtPos(lineFrom, -1)?.left ??
-  view.coordsAtPos(lineFrom, 1)?.left ??
-  0;
+const measurePrefixStartLeft = (
+  view: EditorView,
+  bounds: SoftIndentPrefixBounds,
+): number => {
+  const line = view.state.doc.lineAt(bounds.lineFrom);
+  // Top-level list/task lines start with a replace widget at column 0. Measuring
+  // from widget coords skips the gap between the text-indent origin (line box +
+  // {@link SOFT_INDENT_BASE_PADDING}) and the bullet, so the first row body sits
+  // ~0.2em right of wrapped rows.
+  const prefixStartsAtLineStart =
+    bounds.lineFrom === line.from && !/^[ \t>]/.test(bounds.prefix);
+
+  if (prefixStartsAtLineStart) {
+    const lineEl = lineElementAt(view, line.from);
+    if (lineEl) {
+      return lineEl.getBoundingClientRect().left + SOFT_INDENT_BASE_PADDING;
+    }
+  }
+
+  return (
+    view.coordsAtPos(bounds.lineFrom, -1)?.left ??
+    view.coordsAtPos(bounds.lineFrom, 1)?.left ??
+    0
+  );
+};
 
 /**
  * Left edge where body text should begin — right edge of the visual prefix.
@@ -131,7 +165,7 @@ export const measureSoftIndentWidth = (
   view: EditorView,
   bounds: SoftIndentPrefixBounds,
 ): number => {
-  const start = measurePrefixStartLeft(view, bounds.lineFrom);
+  const start = measurePrefixStartLeft(view, bounds);
   const end = measureBodyStartLeft(view, bounds);
   return Math.max(0, end - start);
 };
@@ -238,7 +272,7 @@ export const softIndentExtension = ViewPlugin.fromClass(
 
       for (const { lineNumber, indentWidth } of indents) {
         const line = view.state.doc.line(lineNumber);
-        const padding = `${(indentWidth + 6).toString()}px`;
+        const padding = `${(indentWidth + SOFT_INDENT_BASE_PADDING).toString()}px`;
         const style = `padding-inline-start: ${padding}; text-indent: -${indentWidth.toString()}px;`;
         styles.set(lineNumber, style);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Top-level list items show a ~1–2px horizontal offset between the first visual row and wrapped continuation rows. Nested list items (2nd/3rd level) align correctly.

## Root cause

Soft indent uses a hanging-indent layout:

- `padding-inline-start: indentWidth + 6px`
- `text-indent: -indentWidth`

On the first row, body text should start at `lineLeft + padding`. That requires `indentWidth` to equal the full in-flow width of the prefix (bullet widget + space).

Prefix width was measured from `coordsAtPos` at the first prefix character or replace widget. That does not match the first-row text-indent origin (`lineLeft + 6px`). For top-level items, the bullet widget's horizontal margin creates a ~0.2em gap between those two points, so `text-indent` under-pulled the first row.

## Fix

Always measure prefix width from the line text-indent origin: `lineElement.getBoundingClientRect().left + 6`. The prefix always hangs from that point regardless of nesting level, replace widgets, or leading whitespace.

## Testing

- `apps/debug-vsc-extn-in-web/e2e/soft-indent-wrap-alignment.spec.ts` — asserts first-row and wrapped-row body text align within 1px at top, nested, and deep nesting levels.
- Existing soft-indent e2e tests pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d051b724-3869-45d3-b5e4-b54ddd4c525e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d051b724-3869-45d3-b5e4-b54ddd4c525e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

